### PR TITLE
Designs for bulk updating MNO requests

### DIFF
--- a/app/data/fake-mno-requests.js
+++ b/app/data/fake-mno-requests.js
@@ -25,7 +25,7 @@ function generateFakeRequests (count) {
           ]),
           classes: 'govuk-tag--red'
         },
-        { text: 'Complete', classes: 'govuk-tag--green' }
+        { text: 'Completed', classes: 'govuk-tag--green' }
       ]),
       network: faker.random.arrayElement([
         'Three', 'Three',

--- a/app/views/mno/_shared/_change-status-form.html
+++ b/app/views/mno/_shared/_change-status-form.html
@@ -5,7 +5,11 @@
       <option value=""></option>
       <option value="in_progress">In progress</option>
       <option value="completed">Completed</option>
-      <option value="not_valid">Not valid</option>
+      <option value="problem">Problem – No account with this number</option>
+      <option value="problem">Problem – Not eligible</option>
+      <option value="problem">Problem – Not a valid mobile number</option>
+      <option value="problem">Problem – No account with this name</option>
+      <option value="problem">Problem – Another reason</option>
     </select>
     <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
       Update

--- a/app/views/mno/_shared/_change-status-form.html
+++ b/app/views/mno/_shared/_change-status-form.html
@@ -1,0 +1,14 @@
+<form action="#" method="post">
+  <div class="govuk-form-group govuk-!-margin-bottom-2">
+    <label class="govuk-label" for="sortby">Set status of selected to</label>
+    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
+      <option value=""></option>
+      <option value="in_progress">In progress</option>
+      <option value="completed">Completed</option>
+      <option value="not_valid">Not valid</option>
+    </select>
+    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
+      Update
+    </button>
+  </div>
+</form>

--- a/app/views/mno/_shared/_requests-table.html
+++ b/app/views/mno/_shared/_requests-table.html
@@ -1,29 +1,3 @@
-{% extends "layout.html" %}
-{% set count = 400 %}
-{% set title = count + " requests" %}
-{% block pageTitle %}{{ title }}{% endblock %}
-
-{% block pageNavigation %}
-  {{ govukBackLink({
-    href: "/mno/index-3"
-  }) }}
-{% endblock %}
-
-{% block content %}
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      {{ title }}
-    </h1>
-  </div>
-</div>
-
-{{ govukButton({
-  text: 'Download requests as CSV',
-  href: '/public/images/sample.csv'
-}) }}
-
 <table class="govuk-table requests-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
@@ -43,7 +17,8 @@
   </thead>
   <tbody class="govuk-table__body">
     {% for request in data.mno.requests %}
-      {% if loop.index <= count %}
+      {% if (count and loop.index <= count) or not count %}
+        {% set tag = overrideTag or request.tag %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
             <div class="govuk-checkboxes__item">
@@ -55,11 +30,11 @@
           </td>
           <td class="govuk-table__cell">{{ request.number }}</td>
           <td class="govuk-table__cell">{{ request.date }}</td>
-          <td class="govuk-table__cell">{{ govukTag(request.tag) }}</td>
+          <td class="govuk-table__cell">{{ govukTag(tag) }}</td>
           <td class="govuk-table__cell">
-            {% if request.tag.classes == 'govuk-tag--red' %}
+            {% if tag.classes == 'govuk-tag--red' %}
               <a href="/mno/report-a-problem">Change problem</a>
-            {% elseif request.tag.text != 'Complete' %}
+            {% elseif tag.text != 'Completed' %}
               <a href="/mno/report-a-problem">Report a problem</a>
             {% endif %}
           </td>
@@ -68,7 +43,3 @@
     {% endfor %}
   </tbody>
 </table>
-
-{% include 'mno/_shared/_requests-table.html' %}
-{% include 'mno/_shared/_change-status-form.html' %}
-{% endblock %}

--- a/app/views/mno/all-completed.html
+++ b/app/views/mno/all-completed.html
@@ -24,44 +24,7 @@
   href: '/public/images/sample.csv'
 }) }}
 
-<table class="govuk-table requests-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header">
-        <div class="govuk-checkboxes__item">
-          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
-          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
-            Account holder
-          </label>
-        </div>
-      </th>
-      <th class="govuk-table__header">Mobile number</th>
-      <th class="govuk-table__header"><a href="#">Requested</a></th>
-      <th class="govuk-table__header"><a href="#">Status</a></th>
-      <th class="govuk-table__header">Actions</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    {% for request in data.mno.requests %}
-      {% if loop.index <= count %}
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
-              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
-                {{ request.name }}
-              </label>
-            </div>
-          </td>
-          <td class="govuk-table__cell">{{ request.number }}</td>
-          <td class="govuk-table__cell">{{ request.date }}</td>
-          <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--green", text: "Completed" }) }}</td>
-          <td class="govuk-table__cell"></td>
-        </tr>
-      {% endif %}
-    {% endfor %}
-  </tbody>
-</table>
-
+{% set overrideTag = { classes: "govuk-tag--green", text: "Completed" } %}
+{% include 'mno/_shared/_requests-table.html' %}
 {% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/all-completed.html
+++ b/app/views/mno/all-completed.html
@@ -1,0 +1,80 @@
+{% extends "layout.html" %}
+{% set count = 70 %}
+{% set title = count + " completed requests" %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/mno/index-3"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+  </div>
+</div>
+
+{{ govukButton({
+  text: 'Download completed requests as CSV',
+  href: '/public/images/sample.csv'
+}) }}
+
+<table class="govuk-table requests-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
+          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
+            Account holder
+          </label>
+        </div>
+      </th>
+      <th class="govuk-table__header">Mobile number</th>
+      <th class="govuk-table__header"><a href="#">Requested</a></th>
+      <th class="govuk-table__header"><a href="#">Status</a></th>
+      <th class="govuk-table__header">Actions</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    {% for request in data.mno.requests %}
+      {% if loop.index <= count %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
+              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
+                {{ request.name }}
+              </label>
+            </div>
+          </td>
+          <td class="govuk-table__cell">{{ request.number }}</td>
+          <td class="govuk-table__cell">{{ request.date }}</td>
+          <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--green", text: "Completed" }) }}</td>
+          <td class="govuk-table__cell"></td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+  </tbody>
+</table>
+
+<form action="#" method="post">
+  <div class="govuk-form-group govuk-!-margin-bottom-2">
+    <label class="govuk-label" for="sortby">Set status of selected to</label>
+    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
+      <option value=""></option>
+      <option value="in_progress">In progress</option>
+      <option value="completed">Completed</option>
+      <option value="not_valid">Not valid</option>
+    </select>
+    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
+      Update
+    </button>
+  </div>
+</form>
+{% endblock %}

--- a/app/views/mno/all-completed.html
+++ b/app/views/mno/all-completed.html
@@ -63,18 +63,5 @@
   </tbody>
 </table>
 
-<form action="#" method="post">
-  <div class="govuk-form-group govuk-!-margin-bottom-2">
-    <label class="govuk-label" for="sortby">Set status of selected to</label>
-    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
-      <option value=""></option>
-      <option value="in_progress">In progress</option>
-      <option value="completed">Completed</option>
-      <option value="not_valid">Not valid</option>
-    </select>
-    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
-      Update
-    </button>
-  </div>
-</form>
+{% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/all-in-progress.html
+++ b/app/views/mno/all-in-progress.html
@@ -65,18 +65,5 @@
   </tbody>
 </table>
 
-<form action="#" method="post">
-  <div class="govuk-form-group govuk-!-margin-bottom-2">
-    <label class="govuk-label" for="sortby">Set status of selected to</label>
-    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
-      <option value=""></option>
-      <option value="in_progress">In progress</option>
-      <option value="completed">Completed</option>
-      <option value="not_valid">Not valid</option>
-    </select>
-    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
-      Update
-    </button>
-  </div>
-</form>
+{% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/all-in-progress.html
+++ b/app/views/mno/all-in-progress.html
@@ -24,46 +24,7 @@
   href: '/public/images/sample.csv'
 }) }}
 
-<table class="govuk-table requests-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header">
-        <div class="govuk-checkboxes__item">
-          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
-          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
-            Account holder
-          </label>
-        </div>
-      </th>
-      <th class="govuk-table__header">Mobile number</th>
-      <th class="govuk-table__header"><a href="#">Requested</a></th>
-      <th class="govuk-table__header"><a href="#">Status</a></th>
-      <th class="govuk-table__header">Actions</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    {% for request in data.mno.requests %}
-      {% if loop.index <= count %}
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
-              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
-                {{ request.name }}
-              </label>
-            </div>
-          </td>
-          <td class="govuk-table__cell">{{ request.number }}</td>
-          <td class="govuk-table__cell">{{ request.date }}</td>
-          <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--yellow", text: "In progress" }) }}</td>
-          <td class="govuk-table__cell">
-            <a href="/mno/report-a-problem">Report a problem</a>
-          </td>
-        </tr>
-      {% endif %}
-    {% endfor %}
-  </tbody>
-</table>
-
+{% set overrideTag = { classes: "govuk-tag--yellow", text: "In progress" } %}
+{% include 'mno/_shared/_requests-table.html' %}
 {% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/all-in-progress.html
+++ b/app/views/mno/all-in-progress.html
@@ -1,0 +1,82 @@
+{% extends "layout.html" %}
+{% set count = 2 %}
+{% set title = count + " requests in progress" %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/mno/index-3"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+  </div>
+</div>
+
+{{ govukButton({
+  text: 'Download in progress requests as CSV',
+  href: '/public/images/sample.csv'
+}) }}
+
+<table class="govuk-table requests-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
+          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
+            Account holder
+          </label>
+        </div>
+      </th>
+      <th class="govuk-table__header">Mobile number</th>
+      <th class="govuk-table__header"><a href="#">Requested</a></th>
+      <th class="govuk-table__header"><a href="#">Status</a></th>
+      <th class="govuk-table__header">Actions</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    {% for request in data.mno.requests %}
+      {% if loop.index <= count %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
+              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
+                {{ request.name }}
+              </label>
+            </div>
+          </td>
+          <td class="govuk-table__cell">{{ request.number }}</td>
+          <td class="govuk-table__cell">{{ request.date }}</td>
+          <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--yellow", text: "In progress" }) }}</td>
+          <td class="govuk-table__cell">
+            <a href="/mno/report-a-problem">Report a problem</a>
+          </td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+  </tbody>
+</table>
+
+<form action="#" method="post">
+  <div class="govuk-form-group govuk-!-margin-bottom-2">
+    <label class="govuk-label" for="sortby">Set status of selected to</label>
+    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
+      <option value=""></option>
+      <option value="in_progress">In progress</option>
+      <option value="completed">Completed</option>
+      <option value="not_valid">Not valid</option>
+    </select>
+    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
+      Update
+    </button>
+  </div>
+</form>
+{% endblock %}

--- a/app/views/mno/all-new.html
+++ b/app/views/mno/all-new.html
@@ -65,18 +65,5 @@
   </tbody>
 </table>
 
-<form action="#" method="post">
-  <div class="govuk-form-group govuk-!-margin-bottom-2">
-    <label class="govuk-label" for="sortby">Set status of selected to</label>
-    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
-      <option value=""></option>
-      <option value="in_progress">In progress</option>
-      <option value="completed">Completed</option>
-      <option value="not_valid">Not valid</option>
-    </select>
-    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
-      Update
-    </button>
-  </div>
-</form>
+{% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/all-new.html
+++ b/app/views/mno/all-new.html
@@ -1,0 +1,82 @@
+{% extends "layout.html" %}
+{% set count = 300 %}
+{% set title = count + " new requests" %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/mno/index-3"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+  </div>
+</div>
+
+{{ govukButton({
+  text: 'Download new requests as CSV',
+  href: '/public/images/sample.csv'
+}) }}
+
+<table class="govuk-table requests-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
+          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
+            Account holder
+          </label>
+        </div>
+      </th>
+      <th class="govuk-table__header">Mobile number</th>
+      <th class="govuk-table__header"><a href="#">Requested</a></th>
+      <th class="govuk-table__header"><a href="#">Status</a></th>
+      <th class="govuk-table__header">Actions</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    {% for request in data.mno.requests %}
+      {% if loop.index <= count %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
+              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
+                {{ request.name }}
+              </label>
+            </div>
+          </td>
+          <td class="govuk-table__cell">{{ request.number }}</td>
+          <td class="govuk-table__cell">{{ request.date }}</td>
+          <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--blue", text: "New" }) }}</td>
+          <td class="govuk-table__cell">
+            <a href="/mno/report-a-problem">Report a problem</a>
+          </td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+  </tbody>
+</table>
+
+<form action="#" method="post">
+  <div class="govuk-form-group govuk-!-margin-bottom-2">
+    <label class="govuk-label" for="sortby">Set status of selected to</label>
+    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
+      <option value=""></option>
+      <option value="in_progress">In progress</option>
+      <option value="completed">Completed</option>
+      <option value="not_valid">Not valid</option>
+    </select>
+    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
+      Update
+    </button>
+  </div>
+</form>
+{% endblock %}

--- a/app/views/mno/all-new.html
+++ b/app/views/mno/all-new.html
@@ -24,46 +24,7 @@
   href: '/public/images/sample.csv'
 }) }}
 
-<table class="govuk-table requests-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header">
-        <div class="govuk-checkboxes__item">
-          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
-          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
-            Account holder
-          </label>
-        </div>
-      </th>
-      <th class="govuk-table__header">Mobile number</th>
-      <th class="govuk-table__header"><a href="#">Requested</a></th>
-      <th class="govuk-table__header"><a href="#">Status</a></th>
-      <th class="govuk-table__header">Actions</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    {% for request in data.mno.requests %}
-      {% if loop.index <= count %}
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
-              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
-                {{ request.name }}
-              </label>
-            </div>
-          </td>
-          <td class="govuk-table__cell">{{ request.number }}</td>
-          <td class="govuk-table__cell">{{ request.date }}</td>
-          <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--blue", text: "New" }) }}</td>
-          <td class="govuk-table__cell">
-            <a href="/mno/report-a-problem">Report a problem</a>
-          </td>
-        </tr>
-      {% endif %}
-    {% endfor %}
-  </tbody>
-</table>
-
+{% set overrideTag = { classes: "govuk-tag--blue", text: "New" } %}
+{% include 'mno/_shared/_requests-table.html' %}
 {% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/all-problem.html
+++ b/app/views/mno/all-problem.html
@@ -24,66 +24,7 @@
   href: '/public/images/sample.csv'
 }) }}
 
-<table class="govuk-table requests-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header">
-        <div class="govuk-checkboxes__item">
-          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
-          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
-            Account holder
-          </label>
-        </div>
-      </th>
-      <th class="govuk-table__header">Mobile number</th>
-      <th class="govuk-table__header"><a href="#">Requested</a></th>
-      <th class="govuk-table__header"><a href="#">Status</a></th>
-      <th class="govuk-table__header">Actions</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    {% for request in data.mno.requests %}
-      {% if loop.index <= count and request.tag.classes == 'govuk-tag--red' %}
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
-              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
-                {{ request.name }}
-              </label>
-            </div>
-          </td>
-          <td class="govuk-table__cell">{{ request.number }}</td>
-          <td class="govuk-table__cell">{{ request.date }}</td>
-          <td class="govuk-table__cell">{{ govukTag(request.tag) }}</td>
-          <td class="govuk-table__cell">
-            <a href="/mno/report-a-problem">Change problem</a>
-          </td>
-        </tr>
-      {% endif %}
-    {% endfor %}
-    {% for request in data.mno.requests %}
-      {% if loop.index <= count and request.tag.classes == 'govuk-tag--red' %}
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
-              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
-                {{ request.name }}
-              </label>
-            </div>
-          </td>
-          <td class="govuk-table__cell">{{ request.number }}</td>
-          <td class="govuk-table__cell">{{ request.date }}</td>
-          <td class="govuk-table__cell">{{ govukTag(request.tag) }}</td>
-          <td class="govuk-table__cell">
-            <a href="/mno/report-a-problem">Change problem</a>
-          </td>
-        </tr>
-      {% endif %}
-    {% endfor %}
-  </tbody>
-</table>
-
+{% set overrideTag = { classes: "govuk-tag--red", text: "Unknown number" } %}
+{% include 'mno/_shared/_requests-table.html' %}
 {% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/all-problem.html
+++ b/app/views/mno/all-problem.html
@@ -85,18 +85,5 @@
   </tbody>
 </table>
 
-<form action="#" method="post">
-  <div class="govuk-form-group govuk-!-margin-bottom-2">
-    <label class="govuk-label" for="sortby">Set status of selected to</label>
-    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
-      <option value=""></option>
-      <option value="in_progress">In progress</option>
-      <option value="completed">Completed</option>
-      <option value="not_valid">Not valid</option>
-    </select>
-    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
-      Update
-    </button>
-  </div>
-</form>
+{% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/all-problem.html
+++ b/app/views/mno/all-problem.html
@@ -1,0 +1,102 @@
+{% extends "layout.html" %}
+{% set count = 28 %}
+{% set title = count + " requests with problems" %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/mno/index-3"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+  </div>
+</div>
+
+{{ govukButton({
+  text: 'Download requests with problems as CSV',
+  href: '/public/images/sample.csv'
+}) }}
+
+<table class="govuk-table requests-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
+          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
+            Account holder
+          </label>
+        </div>
+      </th>
+      <th class="govuk-table__header">Mobile number</th>
+      <th class="govuk-table__header"><a href="#">Requested</a></th>
+      <th class="govuk-table__header"><a href="#">Status</a></th>
+      <th class="govuk-table__header">Actions</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    {% for request in data.mno.requests %}
+      {% if loop.index <= count and request.tag.classes == 'govuk-tag--red' %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
+              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
+                {{ request.name }}
+              </label>
+            </div>
+          </td>
+          <td class="govuk-table__cell">{{ request.number }}</td>
+          <td class="govuk-table__cell">{{ request.date }}</td>
+          <td class="govuk-table__cell">{{ govukTag(request.tag) }}</td>
+          <td class="govuk-table__cell">
+            <a href="/mno/report-a-problem">Change problem</a>
+          </td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+    {% for request in data.mno.requests %}
+      {% if loop.index <= count and request.tag.classes == 'govuk-tag--red' %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
+              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
+                {{ request.name }}
+              </label>
+            </div>
+          </td>
+          <td class="govuk-table__cell">{{ request.number }}</td>
+          <td class="govuk-table__cell">{{ request.date }}</td>
+          <td class="govuk-table__cell">{{ govukTag(request.tag) }}</td>
+          <td class="govuk-table__cell">
+            <a href="/mno/report-a-problem">Change problem</a>
+          </td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+  </tbody>
+</table>
+
+<form action="#" method="post">
+  <div class="govuk-form-group govuk-!-margin-bottom-2">
+    <label class="govuk-label" for="sortby">Set status of selected to</label>
+    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
+      <option value=""></option>
+      <option value="in_progress">In progress</option>
+      <option value="completed">Completed</option>
+      <option value="not_valid">Not valid</option>
+    </select>
+    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
+      Update
+    </button>
+  </div>
+</form>
+{% endblock %}

--- a/app/views/mno/all.html
+++ b/app/views/mno/all.html
@@ -1,0 +1,86 @@
+{% extends "layout.html" %}
+{% set count = 400 %}
+{% set title = count + " requests" %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/mno/index-3"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+  </div>
+</div>
+
+{{ govukButton({
+  text: 'Download requests as CSV',
+  href: '/public/images/sample.csv'
+}) }}
+
+<table class="govuk-table requests-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
+          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
+            Account holder
+          </label>
+        </div>
+      </th>
+      <th class="govuk-table__header">Mobile number</th>
+      <th class="govuk-table__header"><a href="#">Requested</a></th>
+      <th class="govuk-table__header"><a href="#">Status</a></th>
+      <th class="govuk-table__header">Actions</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    {% for request in data.mno.requests %}
+      {% if loop.index <= count %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
+              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
+                {{ request.name }}
+              </label>
+            </div>
+          </td>
+          <td class="govuk-table__cell">{{ request.number }}</td>
+          <td class="govuk-table__cell">{{ request.date }}</td>
+          <td class="govuk-table__cell">{{ govukTag(request.tag) }}</td>
+          <td class="govuk-table__cell">
+            {% if request.tag.classes == 'govuk-tag--red' %}
+              <a href="/mno/report-a-problem">Change problem</a>
+            {% elseif request.tag.text != 'Complete' %}
+              <a href="/mno/report-a-problem">Report a problem</a>
+            {% endif %}
+          </td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+  </tbody>
+</table>
+
+<form action="#" method="post">
+  <div class="govuk-form-group govuk-!-margin-bottom-2">
+    <label class="govuk-label" for="sortby">Set status of selected to</label>
+    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
+      <option value=""></option>
+      <option value="in_progress">In progress</option>
+      <option value="completed">Completed</option>
+      <option value="not_valid">Not valid</option>
+    </select>
+    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
+      Update
+    </button>
+  </div>
+</form>
+{% endblock %}

--- a/app/views/mno/all.html
+++ b/app/views/mno/all.html
@@ -69,18 +69,5 @@
   </tbody>
 </table>
 
-<form action="#" method="post">
-  <div class="govuk-form-group govuk-!-margin-bottom-2">
-    <label class="govuk-label" for="sortby">Set status of selected to</label>
-    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
-      <option value=""></option>
-      <option value="in_progress">In progress</option>
-      <option value="completed">Completed</option>
-      <option value="not_valid">Not valid</option>
-    </select>
-    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
-      Update
-    </button>
-  </div>
-</form>
+{% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/csv-uploaded.html
+++ b/app/views/mno/csv-uploaded.html
@@ -1,0 +1,112 @@
+{% extends "layout.html" %}
+{% set title = "We’ve processed your CSV" %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/mno/upload-csv"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+
+    <p>We found 47 rows in your CSV:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>4 were not changed</li>
+      <li>3 contain errors</li>
+      <li>40 were updated successfully</li>
+    </ul>
+  </div>
+</div>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-4">3 requests contain errors</h2>
+
+<div class="govuk-form-group--error">
+  <p class="govuk-error-message">Fix the errors in your CSV and try uploading again</p>
+
+  <table class="govuk-table requests-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">ID</th>
+        <th class="govuk-table__header">Account holder</th>
+        <th class="govuk-table__header">Mobile number</th>
+        <th class="govuk-table__header">Error</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          10
+        </td>
+        <td class="govuk-table__cell">
+          {{ data.mno.requests[10].name }}
+        </td>
+        <td class="govuk-table__cell">01234 321456</td>
+        <td class="govuk-table__cell">
+          <span class="govuk-error-message govuk-!-margin-bottom-0">
+            Phone number does not match our records<br />We expected 01222 321456
+          </span>
+        </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          15
+        </td>
+        <td class="govuk-table__cell">
+          {{ data.mno.requests[15].name }}
+        </td>
+        <td class="govuk-table__cell">07123456789</td>
+        <td class="govuk-table__cell">
+          <span class="govuk-error-message govuk-!-margin-bottom-0">
+            Account holder does not match our records<br />We expected Adam Jones
+          </span>
+        </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          20
+        </td>
+        <td class="govuk-table__cell">
+          {{ data.mno.requests[20].name }}
+        </td>
+        <td class="govuk-table__cell">07123456789</td>
+        <td class="govuk-table__cell ">
+          <span class="govuk-error-message govuk-!-margin-bottom-0">No status provided</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-4">{{ data.mno.requests | length }} requests updated</h2>
+<table class="govuk-table requests-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">ID</th>
+      <th class="govuk-table__header">Account holder</th>
+      <th class="govuk-table__header">Mobile number</th>
+      <th class="govuk-table__header">New status</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    {% for request in data.mno.requests %}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">{{ loop.index }}</td>
+        <td class="govuk-table__cell">{{ request.name }}</td>
+        <td class="govuk-table__cell">{{ request.number }}</td>
+        <td class="govuk-table__cell">{{ govukTag(request.tag) }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+{{ govukButton({
+  text: 'Finish',
+  href: '/mno'
+}) }}
+{% endblock %}

--- a/app/views/mno/find-requests.html
+++ b/app/views/mno/find-requests.html
@@ -1,0 +1,109 @@
+{% extends "layout.html" %}
+{% set count = 3 %}
+{% set title = count + " requests found" %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/mno/index-2"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+  </div>
+</div>
+
+{{ govukButton({
+  text: 'Download requests as a CSV',
+  href: '/public/images/sample.csv'
+}) }}
+
+<!-- <h2 class="govuk-heading-l">Find requests</h2>
+<div class="app-card govuk-!-margin-bottom-4">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
+        {{ govukTextarea({
+          label: {
+            text: "Names or telephone numbers"
+          },
+          hint: {
+            text: 'Enter one name or telephone number per line'
+          },
+          classes: "govuk-!-margin-bottom-0",
+          id: "mno-name-or-number",
+          name: "mno-name-or-number"
+        }) }}
+
+        {{ govukButton({
+          text: "Find requests",
+          href: "#",
+          classes: "govuk-!-margin-bottom-1"
+        }) }}
+      </fieldset>
+    </div>
+  </div>
+</div> -->
+
+<table class="govuk-table requests-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
+          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
+            Account holder
+          </label>
+        </div>
+      </th>
+      <th class="govuk-table__header">Mobile number</th>
+      <th class="govuk-table__header"><a href="#">Requested</a></th>
+      <th class="govuk-table__header"><a href="#">Status</a></th>
+      <th class="govuk-table__header">Actions</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    {% for request in data.mno.requests %}
+      {% if loop.index <= count %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
+              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
+                {{ request.name }}
+              </label>
+            </div>
+          </td>
+          <td class="govuk-table__cell">{{ request.number }}</td>
+          <td class="govuk-table__cell">{{ request.date }}</td>
+          <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--blue", text: "New" }) }}</td>
+          <td class="govuk-table__cell">
+            <a href="/mno/report-a-problem">Report a problem</a>
+          </td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+  </tbody>
+</table>
+
+<form action="#" method="post">
+  <div class="govuk-form-group govuk-!-margin-bottom-2">
+    <label class="govuk-label" for="sortby">Set status of selected to</label>
+    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
+      <option value=""></option>
+      <option value="in_progress">In progress</option>
+      <option value="completed">Completed</option>
+      <option value="not_valid">Not valid</option>
+    </select>
+    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
+      Update
+    </button>
+  </div>
+</form>
+{% endblock %}

--- a/app/views/mno/find-requests.html
+++ b/app/views/mno/find-requests.html
@@ -24,73 +24,7 @@
   href: '/public/images/sample.csv'
 }) }}
 
-<!-- <h2 class="govuk-heading-l">Find requests</h2>
-<div class="app-card govuk-!-margin-bottom-4">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
-        {{ govukTextarea({
-          label: {
-            text: "Names or telephone numbers"
-          },
-          hint: {
-            text: 'Enter one name or telephone number per line'
-          },
-          classes: "govuk-!-margin-bottom-0",
-          id: "mno-name-or-number",
-          name: "mno-name-or-number"
-        }) }}
-
-        {{ govukButton({
-          text: "Find requests",
-          href: "#",
-          classes: "govuk-!-margin-bottom-1"
-        }) }}
-      </fieldset>
-    </div>
-  </div>
-</div> -->
-
-<table class="govuk-table requests-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header">
-        <div class="govuk-checkboxes__item">
-          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
-          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
-            Account holder
-          </label>
-        </div>
-      </th>
-      <th class="govuk-table__header">Mobile number</th>
-      <th class="govuk-table__header"><a href="#">Requested</a></th>
-      <th class="govuk-table__header"><a href="#">Status</a></th>
-      <th class="govuk-table__header">Actions</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    {% for request in data.mno.requests %}
-      {% if loop.index <= count %}
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
-              <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
-                {{ request.name }}
-              </label>
-            </div>
-          </td>
-          <td class="govuk-table__cell">{{ request.number }}</td>
-          <td class="govuk-table__cell">{{ request.date }}</td>
-          <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--blue", text: "New" }) }}</td>
-          <td class="govuk-table__cell">
-            <a href="/mno/report-a-problem">Report a problem</a>
-          </td>
-        </tr>
-      {% endif %}
-    {% endfor %}
-  </tbody>
-</table>
-
+{% set overrideTag = { classes: "govuk-tag--blue", text: "new" } %}
+{% include 'mno/_shared/_requests-table.html' %}
 {% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/find-requests.html
+++ b/app/views/mno/find-requests.html
@@ -92,18 +92,5 @@
   </tbody>
 </table>
 
-<form action="#" method="post">
-  <div class="govuk-form-group govuk-!-margin-bottom-2">
-    <label class="govuk-label" for="sortby">Set status of selected to</label>
-    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
-      <option value=""></option>
-      <option value="in_progress">In progress</option>
-      <option value="completed">Completed</option>
-      <option value="not_valid">Not valid</option>
-    </select>
-    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
-      Update
-    </button>
-  </div>
-</form>
+{% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/index-2.html
+++ b/app/views/mno/index-2.html
@@ -98,18 +98,5 @@
   </tbody>
 </table>
 
-<form action="#" method="post">
-  <div class="govuk-form-group govuk-!-margin-bottom-2">
-    <label class="govuk-label" for="sortby">Set status of selected to</label>
-    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
-      <option value=""></option>
-      <option value="in_progress">In progress</option>
-      <option value="completed">Completed</option>
-      <option value="not_valid">Not valid</option>
-    </select>
-    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
-      Update
-    </button>
-  </div>
-</form>
+{% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/index-2.html
+++ b/app/views/mno/index-2.html
@@ -19,12 +19,41 @@
 </div>
 
 {{ govukButton({
-    text: 'Download requests as a CSV',
-    href: '/public/images/sample.csv'
+  text: 'Download requests as a CSV',
+  href: '/public/images/sample.csv'
 }) }}
 
-<h2 class="govuk-heading-l govuk-!-margin-top-4">{{ data.mno.requests | length }} requests</h2>
+<h2 class="govuk-heading-l">Find requests</h2>
+<div class="app-card govuk-!-margin-bottom-4">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
+        <!-- <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          Find requests
+        </legend> -->
+        {{ govukTextarea({
+          label: {
+            text: "Telephone numbers"
+          },
+          hint: {
+            text: 'Enter one number per line'
+          },
+          classes: "govuk-!-margin-bottom-0",
+          id: "mno-name-or-number",
+          name: "mno-name-or-number"
+        }) }}
 
+        {{ govukButton({
+          text: "Find requests",
+          href: "/mno/find-requests",
+          classes: "govuk-!-margin-bottom-1"
+        }) }}
+      </fieldset>
+    </div>
+  </div>
+</div>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-7">All requests (400)</h2>
 <table class="govuk-table requests-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/mno/index-2.html
+++ b/app/views/mno/index-2.html
@@ -23,20 +23,21 @@
   href: '/public/images/sample.csv'
 }) }}
 
-<h2 class="govuk-heading-l">Find requests</h2>
 <div class="app-card govuk-!-margin-bottom-4">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
-        <!-- <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          Find requests
-        </legend> -->
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          Find requests by telephone number
+        </legend>
+        <!-- <p>Find requests by telephone number and update them.</p> -->
         {{ govukTextarea({
           label: {
-            text: "Telephone numbers"
+            text: "Telephone numbers",
+            classes: "govuk-label--s"
           },
           hint: {
-            text: 'Enter one number per line'
+            text: 'One per line'
           },
           classes: "govuk-!-margin-bottom-0",
           id: "mno-name-or-number",

--- a/app/views/mno/index-3.html
+++ b/app/views/mno/index-3.html
@@ -12,38 +12,50 @@
   </div>
 </div>
 
-{{ govukButton({
+<!-- {{ govukButton({
   text: 'Download all requests as CSV',
   href: '/public/images/sample.csv'
-}) }}
+}) }} -->
 
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" style="width: 25%">Status</th>
       <th class="govuk-table__header">Number of requests</th>
+      <th class="govuk-table__header">View requests</th>
+      <td class="govuk-table__header">Download CSV</td>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell govuk-!-font-weight-bold">{{ govukTag({ classes: "govuk-tag--grey", text: "All requests" }) }}</td>
-      <td class="govuk-table__cell"><a href="/mno/all">400 requests</a></td>
+      <td class="govuk-table__cell">All requests</td>
+      <td class="govuk-table__cell">400</td>
+      <td class="govuk-table__cell"><a href="/mno/all">View all requests</a></td>
+      <td class="govuk-table__cell"><a href="#">Download CSV</a></td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--blue", text: "New" }) }}</td>
-      <td class="govuk-table__cell"><a href="/mno/all-new">300 requests</a></td>
+      <td class="govuk-table__cell">New</td>
+      <td class="govuk-table__cell">300</td>
+      <td class="govuk-table__cell"><a href="/mno/all-new">View new requests</a></td>
+      <td class="govuk-table__cell"><a href="#">Download CSV</a></td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--yellow", text: "In progress" }) }}</td>
-      <td class="govuk-table__cell"><a href="/mno/all-in-progress">2 requests</a></td>
+      <td class="govuk-table__cell">In progress</td>
+      <td class="govuk-table__cell">2</td>
+      <td class="govuk-table__cell"><a href="/mno/all-in-progress">View in progress requests</a></td>
+      <td class="govuk-table__cell"><a href="#">Download CSV</a></td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--green", text: "Completed" }) }}</td>
-      <td class="govuk-table__cell"><a href="/mno/all-completed">70 requests</a></td>
+      <td class="govuk-table__cell">Completed</td>
+      <td class="govuk-table__cell">70</td>
+      <td class="govuk-table__cell"><a href="/mno/all-completed">View completed requests</a></td>
+      <td class="govuk-table__cell"><a href="#">Download CSV</a></td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--red", text: "Problem reported" }) }}</td>
-      <td class="govuk-table__cell"><a href="/mno/all-problem">28 requests</a></td>
+      <td class="govuk-table__cell">Problem reported</td>
+      <td class="govuk-table__cell">28</td>
+      <td class="govuk-table__cell"><a href="/mno/all-problem">View requests with problems</a></td>
+      <td class="govuk-table__cell"><a href="#">Download CSV</a></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/mno/index-3.html
+++ b/app/views/mno/index-3.html
@@ -1,0 +1,81 @@
+{% extends "layout.html" %}
+{% set title = "Requests for extra mobile data" %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">[Network name]</span>
+      Requests for extra mobile&nbsp;data
+    </h1>
+  </div>
+</div>
+
+{{ govukButton({
+  text: 'Download all requests as CSV',
+  href: '/public/images/sample.csv'
+}) }}
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" style="width: 25%">Status</th>
+      <th class="govuk-table__header">Number of requests</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-font-weight-bold">{{ govukTag({ classes: "govuk-tag--grey", text: "All requests" }) }}</td>
+      <td class="govuk-table__cell"><a href="/mno/all">400 requests</a></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--blue", text: "New" }) }}</td>
+      <td class="govuk-table__cell"><a href="/mno/all-new">300 requests</a></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--yellow", text: "In progress" }) }}</td>
+      <td class="govuk-table__cell"><a href="/mno/all-in-progress">2 requests</a></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--green", text: "Completed" }) }}</td>
+      <td class="govuk-table__cell"><a href="/mno/all-completed">70 requests</a></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ classes: "govuk-tag--red", text: "Problem reported" }) }}</td>
+      <td class="govuk-table__cell"><a href="/mno/all-problem">28 requests</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="app-card govuk-!-margin-bottom-4">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          Find requests by telephone number
+        </legend>
+        <!-- <p>Find requests by telephone number and update them.</p> -->
+        {{ govukTextarea({
+          label: {
+            text: "Telephone numbers",
+            classes: "govuk-label--s"
+          },
+          hint: {
+            text: 'One per line'
+          },
+          classes: "govuk-!-margin-bottom-0",
+          id: "mno-name-or-number",
+          name: "mno-name-or-number"
+        }) }}
+
+        {{ govukButton({
+          text: "Find requests",
+          href: "/mno/find-requests",
+          classes: "govuk-!-margin-bottom-1"
+        }) }}
+      </fieldset>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/views/mno/index.html
+++ b/app/views/mno/index.html
@@ -23,6 +23,10 @@
     href: '/public/images/sample.csv'
 }) }}
 
+<p>
+  <a href="/mno/upload-csv">Update requests using a CSV</a>
+</p>
+
 <h2 class="govuk-heading-l govuk-!-margin-top-4">{{ data.mno.requests | length }} requests</h2>
 
 {% include 'mno/_shared/_requests-table.html' %}

--- a/app/views/mno/index.html
+++ b/app/views/mno/index.html
@@ -68,18 +68,5 @@
   </tbody>
 </table>
 
-<form action="#" method="post">
-  <div class="govuk-form-group govuk-!-margin-bottom-2">
-    <label class="govuk-label" for="sortby">Set status of selected to</label>
-    <select class="govuk-select" name="sortby" id="sortby" style="width: 200px">
-      <option value=""></option>
-      <option value="in_progress">In progress</option>
-      <option value="completed">Completed</option>
-      <option value="not_valid">Not valid</option>
-    </select>
-    <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" data-module="govuk-button">
-      Update
-    </button>
-  </div>
-</form>
+{% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/index.html
+++ b/app/views/mno/index.html
@@ -25,48 +25,6 @@
 
 <h2 class="govuk-heading-l govuk-!-margin-top-4">{{ data.mno.requests | length }} requests</h2>
 
-<table class="govuk-table requests-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header">
-        <div class="govuk-checkboxes__item">
-          <input class="govuk-checkboxes__input" id="all-rows" name="all-rows" type="checkbox" value="all-rows">
-          <label class="govuk-label govuk-label--s govuk-checkboxes__label" for="all-rows">
-            Account holder
-          </label>
-        </div>
-      </th>
-      <th class="govuk-table__header">Mobile number</th>
-      <th class="govuk-table__header"><a href="#">Requested</a></th>
-      <th class="govuk-table__header"><a href="#">Status</a></th>
-      <th class="govuk-table__header">Actions</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    {% for request in data.mno.requests %}
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="row-{{ loop.index }}" name="row" type="checkbox" value="row-{{ loop.index }}">
-            <label class="govuk-label govuk-checkboxes__label" for="row-{{ loop.index }}">
-              {{ request.name }}
-            </label>
-          </div>
-        </td>
-        <td class="govuk-table__cell">{{ request.number }}</td>
-        <td class="govuk-table__cell">{{ request.date }}</td>
-        <td class="govuk-table__cell">{{ govukTag(request.tag) }}</td>
-        <td class="govuk-table__cell">
-          {% if request.tag.classes == 'govuk-tag--red' %}
-            <a href="/mno/report-a-problem">Change problem</a>
-          {% elseif request.tag.text != 'Complete' %}
-            <a href="/mno/report-a-problem">Report a problem</a>
-          {% endif %}
-        </td>
-      </tr>
-    {% endfor %}
-  </tbody>
-</table>
-
+{% include 'mno/_shared/_requests-table.html' %}
 {% include 'mno/_shared/_change-status-form.html' %}
 {% endblock %}

--- a/app/views/mno/upload-csv.html
+++ b/app/views/mno/upload-csv.html
@@ -1,0 +1,87 @@
+{% extends "layout.html" %}
+{% set title = "Update requests using a CSV" %}
+{% block pageTitle %}{{ title }}{% endblock %}
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/mno"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+
+    <h2 class="govuk-heading-l">Upload CSV file</h2>
+
+    <form action="#" class="app-card govuk-!-margin-bottom-6">
+      {{ govukFileUpload({
+        id: "file-upload-1",
+        name: "file-upload-1",
+        label: {
+          text: "CSV file",
+          classes: "govuk-label--m"
+        }
+      }) }}
+
+      {{ govukButton({
+        text: "Upload and update requests",
+        classes: "govuk-!-margin-bottom-2"
+      }) }}
+    </form>
+
+    <h2 class="govuk-heading-l">Help updating the CSV</h2>
+
+    <p>You can modify and re-upload your <a href="/public/images/sample.csv">CSV of requests</a>. Only changes to a request’s status will be processed.</p>
+
+    <h3 class="govuk-heading-m">Statuses you can use</h2>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">Status</th>
+          <th class="govuk-table__header">Description</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">new</td>
+          <td class="govuk-table__cell">Request not processed yet</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">in_progress</td>
+          <td class="govuk-table__cell">Request is being processed</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">completed</td>
+          <td class="govuk-table__cell">Request processed successfully</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">problem_not_eligible</td>
+          <td class="govuk-table__cell">Account is not eligible</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">problem_no_account_with_number</td>
+          <td class="govuk-table__cell">No account with this number</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">problem_no_account_with_name</td>
+          <td class="govuk-table__cell">No account with this name</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">problem_invalid_number</td>
+          <td class="govuk-table__cell">Not a valid mobile number</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">problem</td>
+          <td class="govuk-table__cell">Request could not be processed but not reason specified</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/mno/upload-csv.html
+++ b/app/views/mno/upload-csv.html
@@ -17,7 +17,7 @@
 
     <h2 class="govuk-heading-l">Upload CSV file</h2>
 
-    <form action="#" class="app-card govuk-!-margin-bottom-6">
+    <form action="/mno/csv-uploaded" class="app-card govuk-!-margin-bottom-6">
       {{ govukFileUpload({
         id: "file-upload-1",
         name: "file-upload-1",


### PR DESCRIPTION
https://trello.com/c/nB0RHhNk/1248-design-spike-improve-the-scalability-of-the-mno-support-console

Currently there’s no easy way for networks to tell us they’ve processed a bunch of MNO requests – they can only do it one or a few at a time – using the checkboxes in the table. 

This was suitable when the pilot offered small numbers of users and requests to be fulfilled. However, current volumes mean that (Until now we’ve never had significant volume for this to be an issue) MNOs are unlikely to update the status of their requests making things confusing for us and schools. 

We should consider how we can make this functionality more suitable for 'bulk' changes