### PR TITLE
Add pages for each MNO request

### DIFF
--- a/app/data/fake-mno-requests.js
+++ b/app/data/fake-mno-requests.js
@@ -21,7 +21,7 @@ function generateFakeRequests (count) {
             'Unknown name',
             'Not eligible',
             'Not on network',
-            'Not valid'
+            'Other problem'
           ]),
           classes: 'govuk-tag--red'
         },

--- a/app/data/fake-school-requests.js
+++ b/app/data/fake-school-requests.js
@@ -1,0 +1,49 @@
+const faker = require('faker')
+const dateFormat = require('dateformat')
+
+faker.locale = 'en_GB'
+
+function generateFakeRequests (count) {
+  const requests = {}
+
+  for (var i = 0; i < count; i++) {
+    requests[i] = {
+      'mobile-contract-type': faker.random.arrayElement(['Pay monthly', 'Pay as you go (PAYG)']),
+      privacy: ['Yes, the privacy statement has been shared'],
+      name: `${faker.name.firstName()} ${faker.name.lastName()}`,
+      'mobile-number': faker.phone.phoneNumber('07#########'),
+      date: dateFormat(faker.date.recent(), 'd mmmm h:MMtt'),
+      tag: faker.random.arrayElement([
+        { text: 'Requested', classes: 'govuk-tag--blue' },
+        { text: 'In progress', classes: 'govuk-tag--yellow' },
+        {
+          text: faker.random.arrayElement([
+            'Invalid number',
+            'Unknown number',
+            'Unknown name',
+            'Not eligible',
+            'Not on network',
+            'Not valid'
+          ]),
+          classes: 'govuk-tag--red'
+        },
+        { text: 'Completed', classes: 'govuk-tag--green' },
+        { text: 'Unavailable', classes: 'govuk-tag--grey' }
+      ]),
+      'mobile-network': faker.random.arrayElement([
+        'Three', 'Three',
+        'O2', 'O2', 'O2',
+        'GiffGaff',
+        'Vodafone', 'Vodafone',
+        'EE',
+        'Sky mobile',
+        'Virgin mobile',
+        'BT mobile'
+      ])
+    }
+  }
+
+  return requests
+}
+
+module.exports = generateFakeRequests(40)

--- a/app/data/fake-school-requests.js
+++ b/app/data/fake-school-requests.js
@@ -27,8 +27,7 @@ function generateFakeRequests (count) {
           ]),
           classes: 'govuk-tag--red'
         },
-        { text: 'Completed', classes: 'govuk-tag--green' },
-        { text: 'Unavailable', classes: 'govuk-tag--grey' }
+        { text: 'Completed', classes: 'govuk-tag--green' }
       ]),
       'mobile-network': faker.random.arrayElement([
         'Three', 'Three',

--- a/app/data/fake-school-requests.js
+++ b/app/data/fake-school-requests.js
@@ -18,12 +18,12 @@ function generateFakeRequests (count) {
         { text: 'In progress', classes: 'govuk-tag--yellow' },
         {
           text: faker.random.arrayElement([
-            'Invalid number',
+            // 'Invalid number',
             'Unknown number',
             'Unknown name',
             'Not eligible',
-            'Not on network',
-            'Not valid'
+            // 'Not on network',
+            'Other problem'
           ]),
           classes: 'govuk-tag--red'
         },

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,4 +1,5 @@
 const fakeMnoRequests = require('./fake-mno-requests')
+const fakeSchoolRequests = require('./fake-school-requests')
 const fakeSchoolUsers = require('./fake-school-users')
 const fakeRBUsers = require('./fake-rb-users')
 const schoolsInResponsibleBody = require('./responsible-body-schools')
@@ -61,6 +62,7 @@ module.exports = {
   mno: {
     requests: fakeMnoRequests
   },
+  mobile: fakeSchoolRequests,
   'school-users': fakeSchoolUsers,
   'rb-users': fakeRBUsers,
   schools: schoolsInResponsibleBody,

--- a/app/routes/mobile.js
+++ b/app/routes/mobile.js
@@ -58,6 +58,13 @@ module.exports = router => {
   })
 
   router.all([
+    '/responsible-body/internet/mobile/:mobileId/request',
+    '/school/internet/mobile/:mobileId/request'
+  ], function (req, res) {
+    res.render('mobile/request', { mobileId: req.params.mobileId })
+  })
+
+  router.all([
     '/responsible-body/internet/mobile',
     '/school/internet/mobile'
   ], function (req, res) {

--- a/app/views/mobile/request.html
+++ b/app/views/mobile/request.html
@@ -1,5 +1,8 @@
 {% extends "layout.html" %}
-{% set title = "Marlene Schuster" %}
+{% set title = dataValue(["mobile", mobileId, "name"]) %}
+{% set network = dataValue(["mobile", mobileId, "mobile-network"]) %}
+{% set hasProblem = dataValue(["mobile", mobileId, "tag", "classes"]) == "govuk-tag--red" %}
+{% set problem = dataValue(["mobile", mobileId, "tag", "text"]) %}
 {% block pageTitle %}{{ title }}{% endblock %}
 
 {% block pageNavigation %}
@@ -8,88 +11,144 @@
   }) }}
 {% endblock %}
 
-
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl">07123456789</span>
+      <span class="govuk-caption-xl">{{ dataValue(["mobile", mobileId, "mobile-number"]) }}</span>
       {{ title }}
     </h1>
 
-    <div class="govuk-inset-text">
-      <h2 class="govuk-heading-m">Three did not recognise this number</h2>
+    {% if hasProblem %}
+      {% if problem == 'Unknown number' %}
+        <div class="govuk-inset-text">
+          <h2 class="govuk-heading-m">{{ network }} did not recognise this number</h2>
 
-      <p>Check the following:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>the number was typed correctly</li>
-        <li>the correct mobile network was provided</li>
-      </ul>
+          <p>Check the following:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>the number was typed correctly</li>
+            <li>the correct mobile network was provided</li>
+          </ul>
 
-      {{ govukButton({
-        text: 'Make new request',
-        href: '#'
-      }) }}
-    </div>
+          {{ govukButton({
+            text: 'Make new request',
+            href: '#'
+          }) }}
+        </div>
+      {% endif %}
 
-    <div class="govuk-inset-text">
-      <h2 class="govuk-heading-m">Three did not recognise this name</h2>
+      {% if problem == 'Unknown name' %}
+        <div class="govuk-inset-text">
+          <h2 class="govuk-heading-m">{{ network }} did not recognise this name</h2>
 
-      <p>Check the following:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>the correct account holder was given</li>
-        <li>the name matches the name on the bill</li>
-      </ul>
+          <p>Check the following:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>the correct account holder was given</li>
+            <li>the name matches the name on the bill</li>
+          </ul>
 
-      {{ govukButton({
-        text: 'Make new request',
-        href: '#'
-      }) }}
-    </div>
+          {{ govukButton({
+            text: 'Make new request',
+            href: '#'
+          }) }}
+        </div>
+      {% endif %}
 
-    <div class="govuk-inset-text">
-      <h2 class="govuk-heading-m">This account is not eligible for free data</h2>
+      {% if problem == 'Not eligible' %}
+        <div class="govuk-inset-text">
+          <h2 class="govuk-heading-m">{{ network }} told us this account is not eligible</h2>
 
-      <p>This could be because:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>they are a new customer</li>
-        <li>they do not meet the <a href="#">network’s criteria</a></li>
-        <li>they already have fixed line broadband at home</li>
-      </ul>
+          <p>This could be because:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>they are a new {{ network }} customer</li>
+            <li>they do not meet {{ network }}’s criteria</li>
+            <li>they already have fixed line broadband at home</li>
+          </ul>
 
-      <p>You can:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>confirm this person needs internet access</li>
-        <li>check if there’s another mobile account that could be used</li>
-        <li>request a <a href="#">4G wireless router instead</a></li>
-      </ul>
-    </div>
+          <p>You can still:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>confirm this person needs internet access</li>
+            <li>check if there’s another mobile account they could use</li>
+            <li>request a <a href="#">4G wireless router instead</a></li>
+          </ul>
+        </div>
+      {% endif %}
 
+      {% if problem == 'Other problem' %}
+        <div class="govuk-inset-text">
+          <h2 class="govuk-heading-m">{{ network }} couldn’t process this requested</h2>
+
+          <p>They did not give a reason why.</p>
+
+          <p>You can still:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>confirm this person needs internet access</li>
+            <li>check if there’s another mobile account they could use</li>
+            <li>request a <a href="#">4G wireless router instead</a></li>
+          </ul>
+        </div>
+      {% endif %}
+    {% endif %}
+
+    <h2 class="govuk-heading-m">Request details</h2>
     {{ govukSummaryList({
       rows: [
         {
-          key: { text: "Account holder" },
-          value: { text: "Marlene Schuster" }
-        },
-        {
-          key: { text: "Number" },
-          value: { text: "07123456789" }
-        },
-        {
-          key: { text: "Mobile network" },
-          value: { text: "Three" }
-        },
-        {
-          key: { text: "Requested" },
-          value: { text: "18 January 3:59pm" }
-        },
-        {
           key: { text: "Status" },
-          value: { html: govukTag({ classes: 'govuk-tag--red', text: 'Unknown number'}) }
+          value: { html: govukTag(dataValue(["mobile", mobileId, "tag"])) }
+        },
+        {
+          key: { text: "Requested on" },
+          value: { text: dataValue(["mobile", mobileId, "date"]) }
+        },
+        {
+          key: {
+            text: "Account holder"
+          },
+          value: {
+            text: dataValue(["mobile", mobileId, "name"])
+          }
+        },
+        {
+          key: {
+            text: "Mobile number"
+          },
+          value: {
+            text: dataValue(["mobile", mobileId, "mobile-number"])
+          }
+        },
+        {
+          key: {
+            text: "Mobile network"
+          },
+          value: {
+            text: network
+          }
+        },
+        {
+          key: {
+            text: "Pay monthly or pay as you go"
+          },
+          value: {
+            text: dataValue(["mobile", mobileId, "mobile-contract-type"])
+          }
         }
       ]
     }) }}
+
+    <h2 class="govuk-heading-m">{{ network }} offer</h2>
+
+    {% set genericOfferDetailsMarkdown %}
+[placeholder offer details]
+
+* The recipient will get unlimited data until 31 July 2021.
+* The offer is available to both Pay Monthly and Pay-As-You-Go customers.
+* A text message will be sent to the nominated device once the additional data has been added to the account.
+* The network will aim to process the request within 14 days.
+    {% endset %}
+
+    {{ genericOfferDetailsMarkdown | markdownToHTML }}
   </div>
 </div>
 

--- a/app/views/mobile/request.html
+++ b/app/views/mobile/request.html
@@ -1,0 +1,96 @@
+{% extends "layout.html" %}
+{% set title = "Marlene Schuster" %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: mobilePath + "/requests"
+  }) }}
+{% endblock %}
+
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">07123456789</span>
+      {{ title }}
+    </h1>
+
+    <div class="govuk-inset-text">
+      <h2 class="govuk-heading-m">Three did not recognise this number</h2>
+
+      <p>Check the following:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the number was typed correctly</li>
+        <li>the correct mobile network was provided</li>
+      </ul>
+
+      {{ govukButton({
+        text: 'Make new request',
+        href: '#'
+      }) }}
+    </div>
+
+    <div class="govuk-inset-text">
+      <h2 class="govuk-heading-m">Three did not recognise this name</h2>
+
+      <p>Check the following:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the correct account holder was given</li>
+        <li>the name matches the name on the bill</li>
+      </ul>
+
+      {{ govukButton({
+        text: 'Make new request',
+        href: '#'
+      }) }}
+    </div>
+
+    <div class="govuk-inset-text">
+      <h2 class="govuk-heading-m">This account is not eligible for free data</h2>
+
+      <p>This could be because:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>they are a new customer</li>
+        <li>they do not meet the <a href="#">network’s criteria</a></li>
+        <li>they already have fixed line broadband at home</li>
+      </ul>
+
+      <p>You can:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>confirm this person needs internet access</li>
+        <li>check if there’s another mobile account that could be used</li>
+        <li>request a <a href="#">4G wireless router instead</a></li>
+      </ul>
+    </div>
+
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: { text: "Account holder" },
+          value: { text: "Marlene Schuster" }
+        },
+        {
+          key: { text: "Number" },
+          value: { text: "07123456789" }
+        },
+        {
+          key: { text: "Mobile network" },
+          value: { text: "Three" }
+        },
+        {
+          key: { text: "Requested" },
+          value: { text: "18 January 3:59pm" }
+        },
+        {
+          key: { text: "Status" },
+          value: { html: govukTag({ classes: 'govuk-tag--red', text: 'Unknown number'}) }
+        }
+      ]
+    }) }}
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/mobile/requests.html
+++ b/app/views/mobile/requests.html
@@ -50,6 +50,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Account holder</th>
         <th class="govuk-table__header">Mobile number</th>
+        <th class="govuk-table__header">Requested</th>
         <th class="govuk-table__header">Mobile network</th>
         <th class="govuk-table__header">Status</th>
       </tr>
@@ -59,6 +60,7 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">{{ request['name'] }}</td>
           <td class="govuk-table__cell">{{ request['mobile-number'] }}</td>
+          <td class="govuk-table__cell">{{ request['date'] }}</td>
           <td class="govuk-table__cell">{{ request['mobile-network'] }}</td>
           <td class="govuk-table__cell">
             {{ govukTag(request['tag'])}}

--- a/app/views/mobile/requests.html
+++ b/app/views/mobile/requests.html
@@ -61,10 +61,7 @@
           <td class="govuk-table__cell">{{ request['mobile-number'] }}</td>
           <td class="govuk-table__cell">{{ request['mobile-network'] }}</td>
           <td class="govuk-table__cell">
-            {{ govukTag({
-              text: "Requested",
-              classes: "govuk-tag--blue"
-            })}}
+            {{ govukTag(request['tag'])}}
           </td>
         </tr>
       {% endfor %}

--- a/app/views/mobile/requests.html
+++ b/app/views/mobile/requests.html
@@ -44,6 +44,62 @@
   href: mobilePath + '/type'
 }) }}
 
+{% set statusHelpHtml %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p>Visit a request for guidance on what to do if a request is unsuccessful.</p>
+
+    <table class="govuk-table govuk-!-margin-bottom-0">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" style="width: 200px">Status</th>
+          <th class="govuk-table__header">Description</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ govukTag({ classes: 'govuk-tag--blue', text: 'Requested' }) }}</td>
+          <td class="govuk-table__cell">Request has not been processed yet</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ govukTag({ classes: 'govuk-tag--yellow', text: 'In progress' }) }}</td>
+          <td class="govuk-table__cell">Network is currently processing this request</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ govukTag({ classes: 'govuk-tag--green', text: 'Completed' }) }}</td>
+          <td class="govuk-table__cell">Request succesful and offer activated</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ govukTag({ classes: 'govuk-tag--red', text: 'Unknown number' }) }}</td>
+          <td class="govuk-table__cell">No account was found with number given</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ govukTag({ classes: 'govuk-tag--red', text: 'Unknown name' }) }}</td>
+          <td class="govuk-table__cell">No account was found with name given</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ govukTag({ classes: 'govuk-tag--red', text: 'Not eligible' }) }}</td>
+          <td class="govuk-table__cell">The network reported this request was not eligible</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ govukTag({ classes: 'govuk-tag--red', text: 'Other problem' }) }}</td>
+          <td class="govuk-table__cell">The network could not process this request but did not give a reason why</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ govukTag({ classes: 'govuk-tag--grey', text: 'Unavailable' }) }}</td>
+          <td class="govuk-table__cell">This network is not supporting the offer yet</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endset %}
+
+{{ govukDetails({
+  summaryText: "Help with statuses",
+  html: statusHelpHtml
+}) }}
+
 {% if dataValue(["mobile"]) %}
   <table class="govuk-table">
     <thead class="govuk-table__head">

--- a/app/views/mobile/requests.html
+++ b/app/views/mobile/requests.html
@@ -25,11 +25,11 @@
 {% endblock %}
 {% block content %}
 
-{{ appBanner({
+<!-- {{ appBanner({
   html: "<h2 class=\"govuk-heading-m\">We’ve received your request</h2>",
   type: "success",
   icon: false
-}) }}
+}) }} -->
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -58,7 +58,9 @@
     <tbody class="govuk-table__body">
       {% for id, request in dataValue(["mobile"]) %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{ request['name'] }}</td>
+          <td class="govuk-table__cell">
+            <a href="{{ mobilePath }}/request">{{ request['name'] }}</a>
+          </td>
           <td class="govuk-table__cell">{{ request['mobile-number'] }}</td>
           <td class="govuk-table__cell">{{ request['date'] }}</td>
           <td class="govuk-table__cell">{{ request['mobile-network'] }}</td>

--- a/app/views/mobile/requests.html
+++ b/app/views/mobile/requests.html
@@ -59,7 +59,7 @@
       {% for id, request in dataValue(["mobile"]) %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <a href="{{ mobilePath }}/request">{{ request['name'] }}</a>
+            <a href="{{ mobilePath }}/{{ id }}/request">{{ request['name'] }}</a>
           </td>
           <td class="govuk-table__cell">{{ request['mobile-number'] }}</td>
           <td class="govuk-table__cell">{{ request['date'] }}</td>


### PR DESCRIPTION
In research with schools and trusts we’ve found that users do not:

- understand all the MNO statuses
- know where to find details about what each network offers
- know how to respond to a request with a problem

In this design we’ve created a page for each request. On each request we:

- give details about the request
- re-iterate the network offer that’s available for this request
- give next steps when the request has a problem

On the request page we’ve also:

- added a statuses key
- included a requested date on the requests table
- sorted the table by requested date, newest first

https://ghwt-design-history.herokuapp.com/mno-request-pages/