### PR TITLE
giffgaff and O2 wont accept FE student MNO requests

### DIFF
--- a/app/views/mobile/bulk/index.html
+++ b/app/views/mobile/bulk/index.html
@@ -42,7 +42,7 @@
     }) }}
 
     {{ govukWarningText({
-      html: 'giffgaff, O2 and Tesco Mobile will not accept requests for students over the age of 16',
+      html: 'giffgaff and O2 will not accept requests for students over the age of 16',
       iconFallbackText: 'Warning'
     }) }}
 

--- a/app/views/mobile/bulk/index.html
+++ b/app/views/mobile/bulk/index.html
@@ -41,6 +41,11 @@
       }
     }) }}
 
+    {{ govukWarningText({
+      html: 'O2 and giffgaff will not accept requests for students in further&nbsp;education',
+      iconFallbackText: 'Warning'
+    }) }}
+
     {{ govukButton({
       text: 'Upload requests',
       href: mobilePath + '/bulk/uploaded'

--- a/app/views/mobile/bulk/index.html
+++ b/app/views/mobile/bulk/index.html
@@ -42,7 +42,7 @@
     }) }}
 
     {{ govukWarningText({
-      html: 'O2 and giffgaff will not accept requests for students in further&nbsp;education',
+      html: 'giffgaff, O2 and Tesco Mobile will not accept requests for students over the age of 16',
       iconFallbackText: 'Warning'
     }) }}
 

--- a/app/views/mobile/bulk/uploaded.html
+++ b/app/views/mobile/bulk/uploaded.html
@@ -48,11 +48,24 @@
           {{ data.mno.requests[10].name }}
         </td>
         <td class="govuk-table__cell">
-          <span class="govuk-error-message govuk-!-margin-bottom-0">Not a mobile number</span>
+          <span class="govuk-error-message govuk-!-margin-bottom-0">O2 do not accept requests for<br />students in further&nbsp;education</span>
         </td>
         <td class="govuk-table__cell">O2</td>
         <td class="govuk-table__cell">01234 321456</td>
       </tr>
+      <!-- <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          Row 10
+        </td>
+        <td class="govuk-table__cell">
+          {{ data.mno.requests[10].name }}
+        </td>
+        <td class="govuk-table__cell">
+          <span class="govuk-error-message govuk-!-margin-bottom-0">Not a mobile number</span>
+        </td>
+        <td class="govuk-table__cell">O2</td>
+        <td class="govuk-table__cell">01234 321456</td>
+      </tr> -->
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           Row 15

--- a/app/views/mobile/bulk/uploaded.html
+++ b/app/views/mobile/bulk/uploaded.html
@@ -48,7 +48,7 @@
           {{ data.mno.requests[10].name }}
         </td>
         <td class="govuk-table__cell">
-          <span class="govuk-error-message govuk-!-margin-bottom-0">O2 do not accept requests for<br />students in further&nbsp;education</span>
+          <span class="govuk-error-message govuk-!-margin-bottom-0">O2 do not accept requests for<br />students over the age of 16</span>
         </td>
         <td class="govuk-table__cell">O2</td>
         <td class="govuk-table__cell">01234 321456</td>

--- a/app/views/mobile/index.html
+++ b/app/views/mobile/index.html
@@ -36,6 +36,8 @@
       <li>cannot afford additional data</li>
     </ul>
 
+    <p>O2 and giffgaff will not accept mobile data requests for students in further education.</p>
+
     <p>One of the following must also apply. They are children:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>in years 3 to 11 and whose face-to-face education is disrupted</li>

--- a/app/views/mobile/index.html
+++ b/app/views/mobile/index.html
@@ -36,7 +36,7 @@
       <li>cannot afford additional data</li>
     </ul>
 
-    <p>giffgaff, O2 and Tesco Mobile will not accept requests for students over the age of 16.</p>
+    <p>giffgaff and O2 will not accept requests for students over the age of 16.</p>
 
     <p>One of the following must also apply. They are children:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/mobile/index.html
+++ b/app/views/mobile/index.html
@@ -36,7 +36,7 @@
       <li>cannot afford additional data</li>
     </ul>
 
-    <p>O2 and giffgaff will not accept mobile data requests for students in further education.</p>
+    <p>giffgaff, O2 and Tesco Mobile will not accept requests for students over the age of 16.</p>
 
     <p>One of the following must also apply. They are children:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/mobile/new.html
+++ b/app/views/mobile/new.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% set title = "Who needs the extra mobile data?" %}
 {% block pageTitle %}{{ title }}{% endblock %}
+{% set isFe = true %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -56,6 +57,14 @@
       </ul>
     {% endset %}
 
+    {% set hintHtml %}
+      {% if isFe %}
+        Only mobile networks participating in the service are listed.<br />O2 and giffgaff are not shown as they do not accept requests for students in further&nbsp;education.<br /><a href="/guide/asking-for-network">Guidance on asking for mobile network</a> and <a href="/guide/telling-about-offer">telling people about their offer</a>
+      {% else %}
+        Only mobile networks participating in the service are listed<br /><a href="/guide/asking-for-network">Guidance on asking for mobile network</a> and <a href="/guide/telling-about-offer">telling people about their offer</a>
+      {% endif %}
+    {% endset %}
+
     {{ govukRadios({
       fieldset: {
         legend: {
@@ -64,7 +73,7 @@
         }
       },
       hint: {
-        html: 'Only mobile networks participating in the service are listed<br /><a href="/guide/asking-for-network">Guidance on asking for mobile network</a> and <a href="/guide/telling-about-offer">telling people about their offer</a>',
+        html: hintHtml,
         classes: 'govuk-!-margin-bottom-3'
       },
       items: [
@@ -85,7 +94,7 @@
           conditional: {
             html: genericOfferDetailsHTML
           }
-        },
+        } if not isFe,
         {
           text: "Tesco Mobile",
           conditional: {

--- a/app/views/mobile/new.html
+++ b/app/views/mobile/new.html
@@ -59,7 +59,7 @@
 
     {% set hintHtml %}
       {% if isFe %}
-        Only mobile networks participating in the service are listed.<br />giffgaff, O2 and Tesco Mobile are not shown as they do not accept requests for students over the age of 16.<br /><a href="/guide/asking-for-network">Guidance on asking for mobile network</a> and <a href="/guide/telling-about-offer">telling people about their offer</a>
+        Only mobile networks participating in the service are listed.<br />giffgaff and O2 are not shown as they do not accept requests for students over the age of 16.<br /><a href="/guide/asking-for-network">Guidance on asking for mobile network</a> and <a href="/guide/telling-about-offer">telling people about their offer</a>
       {% else %}
         Only mobile networks participating in the service are listed<br /><a href="/guide/asking-for-network">Guidance on asking for mobile network</a> and <a href="/guide/telling-about-offer">telling people about their offer</a>
       {% endif %}
@@ -100,7 +100,7 @@
           conditional: {
             html: genericOfferDetailsHTML
           }
-        } if not isFe,
+        },
         {
           text: "Three",
           conditional: {

--- a/app/views/mobile/new.html
+++ b/app/views/mobile/new.html
@@ -59,7 +59,7 @@
 
     {% set hintHtml %}
       {% if isFe %}
-        Only mobile networks participating in the service are listed.<br />O2 and giffgaff are not shown as they do not accept requests for students in further&nbsp;education.<br /><a href="/guide/asking-for-network">Guidance on asking for mobile network</a> and <a href="/guide/telling-about-offer">telling people about their offer</a>
+        Only mobile networks participating in the service are listed.<br />giffgaff, O2 and Tesco Mobile are not shown as they do not accept requests for students over the age of 16.<br /><a href="/guide/asking-for-network">Guidance on asking for mobile network</a> and <a href="/guide/telling-about-offer">telling people about their offer</a>
       {% else %}
         Only mobile networks participating in the service are listed<br /><a href="/guide/asking-for-network">Guidance on asking for mobile network</a> and <a href="/guide/telling-about-offer">telling people about their offer</a>
       {% endif %}
@@ -100,7 +100,7 @@
           conditional: {
             html: genericOfferDetailsHTML
           }
-        },
+        } if not isFe,
         {
           text: "Three",
           conditional: {


### PR DESCRIPTION
1. Show eligibility message to all users on check who is eligible page
2. Show warning before spreadsheet upload to FE orgs and any centrally managed RB with an FE org in its list
3. Hide gg and O2 from list of networks for an FE org
4. Add validation to prevent uploading a gg or O2 request for an FE org

https://ghwt-design-history.herokuapp.com/fe-mno/