### PR TITLE
Add opt in remaining schools design

### DIFF
--- a/app/routes/donated.js
+++ b/app/routes/donated.js
@@ -7,7 +7,11 @@ const {
  * Donated walkthrough routes
  */
 module.exports = router => {
-  router.get(['/responsible-body/donated/what-devices-do-schools-want', '/responsible-body/donated/which-schools'], (req, res, next) => {
+  router.get([
+    '/responsible-body/donated/remaining-schools',
+    '/responsible-body/donated/what-devices-do-schools-want',
+    '/responsible-body/donated/which-schools'
+  ], (req, res, next) => {
     res.locals.schools = req.session.data.schools.map(school => {
       return {
         text: school.name

--- a/app/utils/donated-wizard-paths.js
+++ b/app/utils/donated-wizard-paths.js
@@ -30,7 +30,10 @@ function donatedWizardPaths (req) {
     '/responsible-body/donated/disclaimer',
     '/responsible-body/donated/check-answers',
     '/responsible-body/donated/opted-in',
-    '/responsible-body'
+    '/responsible-body',
+    '/responsible-body/donated/opted-in',
+    '/responsible-body/donated/remaining-schools',
+    '/responsible-body/donated/opted-in'
   ]
 
   return nextAndBackPaths(paths, req)

--- a/app/views/donated/opted-in.html
+++ b/app/views/donated/opted-in.html
@@ -53,7 +53,7 @@
               {% endfor %}
             </ul>
 
-            <p>You can still <a href="#">opt in the rest of your schools</a>.</p>
+            <p>You can still <a href="/responsible-body/donated/remaining-schools">opt in the rest of your schools</a>.</p>
           {% else %}
             <p>All schools</p>
           {% endif %}

--- a/app/views/donated/remaining-schools.html
+++ b/app/views/donated/remaining-schools.html
@@ -1,6 +1,6 @@
 {% extends "_wizard-form.html" %}
 {% set title = 'Pick the schools you want to opt in' %}
-{% set buttonText = 'Confirm and opt in schools' %}
+{% set buttonText = 'Opt in schools' %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">Pick the schools<br />you want to opt in</h1>

--- a/app/views/donated/remaining-schools.html
+++ b/app/views/donated/remaining-schools.html
@@ -1,0 +1,23 @@
+{% extends "_wizard-form.html" %}
+{% set title = 'Pick the schools you want to opt in' %}
+{% set buttonText = 'Confirm and opt in schools' %}
+
+{% block form %}
+  <h1 class="govuk-heading-xl">Pick the schools<br />you want to opt in</h1>
+
+  {{ govukCheckboxes({
+    items: [
+     {
+       text: 'Select all'
+     }
+    ],
+    formGroup: {
+      classes: 'govuk-!-margin-bottom-0'
+    }
+  } | decorateFormAttributes(["refurbished", "schools"])) }}
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+  {{ govukCheckboxes({
+    items: schools
+  } | decorateFormAttributes(["donated-opt-in-schools"])) }}
+{% endblock %}


### PR DESCRIPTION
When an RB opts in some but not all of their schools, they can return and opt in the rest, this is the design for that page, linked to from the "opted in" page.

It's the same as the "pick which schools" page, only it:

- lists just the schools not opted in yet
- has different button text (Opt in schools)
- the `back` link takes you to the opted in page
- submitting takes to to the opted in page