### PR TITLE
Expand school order journey

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -15,6 +15,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/cookie-banner";
 @import "components/card";
 @import "components/order-card";
+@import "components/summary-card";
 
 // Prototype hack to hide broken breadcrumbs
 // Allows something like this in the template:

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -31,6 +31,10 @@ $govuk-assets-path: '/govuk/assets/';
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 
+.app-\!-font-family-tabular {
+  @include govuk-font($size: false, $tabular: true);
+}
+
 .app-masthead {
   width: 100%;
   position: absolute;
@@ -73,7 +77,7 @@ $govuk-assets-path: '/govuk/assets/';
   margin-right: auto;
 }
 
-.app-below-masthead { 
+.app-below-masthead {
   margin-top: 360px;
  }
 

--- a/app/assets/sass/components/_summary-card.scss
+++ b/app/assets/sass/components/_summary-card.scss
@@ -1,0 +1,80 @@
+.app-summary-card {
+  border: 1px solid $govuk-border-colour;
+
+  /* Card header */
+  .app-summary-card__header {
+    align-items: center;
+    background-color: govuk-colour("light-grey");
+    padding: govuk-spacing(3);
+
+    @include govuk-media-query($from: desktop) {
+      display: flex;
+      justify-content: space-between;
+      align-items: start;
+    }
+  }
+
+  .app-summary-card__title {
+    @include govuk-font($size: 19);
+    margin: 0;
+  }
+
+  .app-summary-card__meta {
+    @include govuk-font($size: 16);
+    display: block;
+    margin: 0;
+  }
+
+  .app-summary-card__actions {
+    @include govuk-font($size: 19);
+  }
+
+  .app-summary-card__actions-list {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  .app-summary-card__actions-list-item {
+    display: block;
+    white-space: nowrap;
+
+    @include govuk-media-query($from: desktop) {
+      display: inline-block;
+      margin-left: govuk-spacing(2);
+      text-align: right;
+    }
+  }
+
+  .app-summary-card__actions-list-item:first-child {
+    margin-left: 0;
+  }
+
+  /* Card body */
+  .app-summary-card__body {
+    @include govuk-font($size: 19);
+    padding: govuk-spacing(3);
+  }
+
+  .govuk-table,
+  .govuk-summary-list,
+  .govuk-table {
+    margin-bottom: 0;
+  }
+
+  .govuk-summary-list__row:last-child,
+  .govuk-summary-list__row:last-child > *,
+  .govuk-table__row:last-child .govuk-table__cell {
+    border-bottom: 0;
+  }
+}
+
+@media print {
+  .app-summary-card__header {
+    break-inside: avoid;
+  }
+
+  .app-summary-card__actions {
+    display: none;
+  }
+}

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -7,33 +7,20 @@ const schoolDetails = require('./school-details')
 
 module.exports = {
   signedInHomePath: '/responsible-body',
-  rb: 'Greenwhich',
   laFundedPlacesAllocation: 20,
-  laFundedPlacesOrdered:0,
-  trust: true,
+  laFundedPlacesOrdered: 0,
+  trust: false,
+  rb: 'Greenwhich',
   rbAddress: [
     'The Woolwich Centre',
     'Wellington Street',
     'Woolwich',
     'SE18 6HQ'
   ],
-  trust: false,
   devicesOrdered: 9,
-  routersAllocated: 0,
+  routersAllocated: 10,
   routersOrdered: 0,
   'who-orders-laptops': 'central',
-  'responsible-body': {
-    140961: {
-      chromebooks: 'yes',
-      domain: 'domain.co.uk',
-      recovery: 'email@email.com'
-    },
-    142900: {
-      chromebooks: 'yes',
-      domain: 'domain.co.uk',
-      recovery: 'email@email.com'
-    }
-  },
   features: {
     iss: true,
     push: true,

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -22,7 +22,7 @@ module.exports = {
   routersOrdered: 0,
   'who-orders-laptops': 'central',
   features: {
-    iss: true,
+    iss: false,
     push: true,
     mno: true,
     donated: true,

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -36,7 +36,8 @@ module.exports = {
     'sign-up': false,
     'bulk-upload': true,
     'in-connectivity-pilots': true,
-    'request-devices-google-form': true
+    'request-devices-google-form': true,
+    'order-in-service': true
   },
   mno: {
     requests: fakeMnoRequests

--- a/app/routes.js
+++ b/app/routes.js
@@ -4,10 +4,10 @@ const router = express.Router()
 require('./routes/mobile')(router)
 require('./routes/family')(router)
 require('./routes/donated')(router)
+require('./routes/shop')(router)
 require('./routes/school')(router)
 require('./routes/guide')(router)
 require('./routes/devices')(router)
-require('./routes/shop')(router)
 
 router.get('/responsible-body/donated-which-schools', (req, res, next) => {
   res.locals.schools = req.session.data.schools.map(school => {

--- a/app/routes/shop.js
+++ b/app/routes/shop.js
@@ -4,18 +4,28 @@ const {
 } = require('../utils/shop-wizard-paths')
 
 /**
- * Family walkthrough routes
+ * Shop walkthrough routes
  */
 module.exports = router => {
-  router.get('/shop', function (req, res) {
+  router.all('/school/shop*', function (req, res, next) {
+    res.locals.isSchool = true
+    next()
+  })
+
+  router.all('/responsible-body/shop*', function (req, res, next) {
+    res.locals.isRb = true
+    next()
+  })
+
+  router.get(['/school/shop', '/responsible-body/shop'], function (req, res) {
     res.render('shop/index', { paths: shopWizardPaths(req) })
   })
 
-  router.get('/shop/:view', function (req, res) {
+  router.get(['/school/shop/:view', '/responsible-body/shop/:view'], function (req, res) {
     res.render(`shop/${req.params.view}`, { paths: shopWizardPaths(req) })
   })
 
-  router.post(['/shop', '/shop/:view'], function (req, res) {
+  router.post(['/school/shop*', '/responsible-body/shop*'], function (req, res) {
     const fork = shopWizardForks(req)
     const paths = shopWizardPaths(req)
     fork ? res.redirect(fork) : res.redirect(paths.next)

--- a/app/utils/school-wizard-paths.js
+++ b/app/utils/school-wizard-paths.js
@@ -4,8 +4,9 @@ const {
 } = require('../utils/wizard-helpers')
 
 function schoolWizardPaths (req) {
-  const isFirstUser = req.session.data['school-details'].first_user
-  const isLAFundedUser = req.session.data.features.iss
+  const data = req.session.data
+  const isFirstUser = data['school-details'].first_user
+  const isLAFundedUser = data.features.iss
 
   var paths = [
     '/school/welcome',
@@ -13,8 +14,8 @@ function schoolWizardPaths (req) {
     '/school/allocation',
     ...isFirstUser ? ['/school/other-ordering'] : [],
     '/school/devices-you-can-order',
-    ...isLAFundedUser ? [] : ['/school/chromebooks'],
-    ...isLAFundedUser ? [] : ['/school/what-next'],
+    ...(isLAFundedUser || data.features['order-in-service']) ? [] : ['/school/chromebooks'],
+    ...(isLAFundedUser || data.features['order-in-service']) ? [] : ['/school/what-next'],
     '/school'
   ]
 

--- a/app/utils/shop-wizard-paths.js
+++ b/app/utils/shop-wizard-paths.js
@@ -9,6 +9,7 @@ function shopWizardPaths (req) {
     '/shop',
     '/shop/how-many',
     '/shop/windows',
+    '/shop/chromebooks',
     '/shop/address',
     '/shop/confirm',
     '/shop/confirmation',

--- a/app/utils/shop-wizard-paths.js
+++ b/app/utils/shop-wizard-paths.js
@@ -7,11 +7,12 @@ function shopWizardPaths (req) {
   var paths = [
     '/shop/devices/order-lockdown',
     '/shop',
-    ...req.session.data.routersAllocated > 0 ? '/shop/how-many-routers' : [],
+    ...req.session.data.routersAllocated > 0 ? ['/shop/how-many-routers'] : [],
     '/shop/how-many',
     '/shop/windows',
     '/shop/chromebooks',
     '/shop/address',
+    '/shop/delivery-contact',
     '/shop/confirm',
     '/shop/confirmation',
     '/school'

--- a/app/utils/shop-wizard-paths.js
+++ b/app/utils/shop-wizard-paths.js
@@ -5,7 +5,7 @@ const {
 
 function shopWizardPaths (req) {
   var paths = [
-    '/school/shop/devices/order-lockdown',
+    '/school/devices/order-in-service',
     '/school/shop',
     ...req.session.data.routersAllocated > 0 ? ['/school/shop/how-many-routers'] : [],
     '/school/shop/how-many',

--- a/app/utils/shop-wizard-paths.js
+++ b/app/utils/shop-wizard-paths.js
@@ -7,6 +7,7 @@ function shopWizardPaths (req) {
   var paths = [
     '/shop/devices/order-lockdown',
     '/shop',
+    ...req.session.data.routersAllocated > 0 ? '/shop/how-many-routers' : [],
     '/shop/how-many',
     '/shop/windows',
     '/shop/chromebooks',
@@ -20,17 +21,17 @@ function shopWizardPaths (req) {
 }
 
 function shopWizardForks (req) {
-  // var forks = {
-  //   '/shop/you-ordering': {
-  //     'you-ordering': {
-  //       values: [
-  //         'No'
-  //       ],
-  //       path: '/shop/other-ordering'
-  //     }
-  //   }
-  // }
-  return nextForkPath({}, req)
+  var forks = {
+    '/shop': {
+      'shop-devices': {
+        excludedValues: [
+          '4G Wireless router'
+        ],
+        path: '/shop/how-many'
+      }
+    }
+  }
+  return nextForkPath(forks, req)
 }
 
 module.exports = {

--- a/app/utils/shop-wizard-paths.js
+++ b/app/utils/shop-wizard-paths.js
@@ -5,16 +5,16 @@ const {
 
 function shopWizardPaths (req) {
   var paths = [
-    '/shop/devices/order-lockdown',
-    '/shop',
-    ...req.session.data.routersAllocated > 0 ? ['/shop/how-many-routers'] : [],
-    '/shop/how-many',
-    '/shop/windows',
-    '/shop/chromebooks',
-    '/shop/address',
-    '/shop/delivery-contact',
-    '/shop/confirm',
-    '/shop/confirmation',
+    '/school/shop/devices/order-lockdown',
+    '/school/shop',
+    ...req.session.data.routersAllocated > 0 ? ['/school/shop/how-many-routers'] : [],
+    '/school/shop/how-many',
+    '/school/shop/windows',
+    '/school/shop/chromebooks',
+    '/school/shop/address',
+    '/school/shop/delivery-contact',
+    '/school/shop/confirm',
+    '/school/shop/confirmation',
     '/school'
   ]
 
@@ -23,12 +23,12 @@ function shopWizardPaths (req) {
 
 function shopWizardForks (req) {
   var forks = {
-    '/shop': {
+    '/school/shop': {
       'shop-devices': {
         excludedValues: [
           '4G Wireless router'
         ],
-        path: '/shop/how-many'
+        path: '/school/shop/how-many'
       }
     }
   }

--- a/app/utils/shop-wizard-paths.js
+++ b/app/utils/shop-wizard-paths.js
@@ -26,7 +26,7 @@ function shopWizardForks (req) {
     '/school/shop': {
       'shop-devices': {
         excludedValues: [
-          '4G Wireless router'
+          '4G wireless router'
         ],
         path: '/school/shop/how-many'
       }

--- a/app/utils/wizard-helpers.js
+++ b/app/utils/wizard-helpers.js
@@ -37,8 +37,9 @@ function nextForkPath (forks, req) {
   if (fork) {
     for (const [key, condition] of Object.entries(fork)) {
       const values = Array.isArray(condition.values) ? condition.values : [condition.values]
+      const storedValues = Array.isArray(data[key]) ? data[key] : [data[key]]
 
-      if (values.includes(data[key])) {
+      if (values.some(v => storedValues.indexOf(v) >= 0)) {
         data['forked-from'] = currentPath
         data['forked-to'] = condition.path
 

--- a/app/utils/wizard-helpers.js
+++ b/app/utils/wizard-helpers.js
@@ -36,14 +36,28 @@ function nextForkPath (forks, req) {
 
   if (fork) {
     for (const [key, condition] of Object.entries(fork)) {
-      const values = Array.isArray(condition.values) ? condition.values : [condition.values]
       const storedValues = Array.isArray(data[key]) ? data[key] : [data[key]]
 
-      if (values.some(v => storedValues.indexOf(v) >= 0)) {
-        data['forked-from'] = currentPath
-        data['forked-to'] = condition.path
+      if (condition.values) {
+        const values = Array.isArray(condition.values) ? condition.values : [condition.values]
 
-        return condition.path
+        if (values.some(v => storedValues.indexOf(v) >= 0)) {
+          data['forked-from'] = currentPath
+          data['forked-to'] = condition.path
+
+          return condition.path
+        }
+      }
+
+      if (condition.excludedValues) {
+        const excludedValues = Array.isArray(condition.excludedValues) ? condition.excludedValues : [condition.excludedValues]
+
+        if (!excludedValues.some(v => storedValues.indexOf(v) >= 0)) {
+          data['forked-from'] = currentPath
+          data['forked-to'] = condition.path
+
+          return condition.path
+        }
       }
     }
   }

--- a/app/views/_components/summary-card/macro.njk
+++ b/app/views/_components/summary-card/macro.njk
@@ -1,0 +1,3 @@
+{% macro appSummaryCard(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/views/_components/summary-card/template.njk
+++ b/app/views/_components/summary-card/template.njk
@@ -1,0 +1,43 @@
+{%- macro _actionLink(action) %}
+  <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+    {{ action.html | safe if action.html else action.text }}
+    {%- if action.visuallyHiddenText -%}
+      <span class="govuk-visually-hidden"> {{ action.visuallyHiddenText }}</span>
+    {% endif -%}
+  </a>
+{% endmacro -%}
+
+<section class="app-summary-card
+  {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  {% if params.titleHtml or params.titleText or params.actions %}
+  <header class="app-summary-card__header">
+    {% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
+    <h{{ headingLevel }} class="app-summary-card__title">
+      {{ params.titleHtml | safe if params.titleHtml else params.titleText }}
+    </h{{ headingLevel }}>
+    {% if params.actions.items.length %}
+      <div class="app-summary-card__actions">
+        {% if params.actions.items.length == 1 %}
+          {{ _actionLink(params.actions.items[0]) | indent(12) | trim }}
+        {% else %}
+          <ul class="app-summary-card__actions-list">
+          {% for action in params.actions.items %}
+            {% if action %}
+              <li class="app-summary-card__actions-list-item">
+                {{ _actionLink(action) | indent(18) | trim }}
+              </li>
+            {% endif %}
+          {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    {% endif %}
+  </header>
+  {% endif %}
+  {% if params.html or params.text %}
+  <div class="app-summary-card__body">
+    {{ params.html | safe if params.html else params.text }}
+  </div>
+  {% endif %}
+</section>

--- a/app/views/_shared/_user.html
+++ b/app/views/_shared/_user.html
@@ -29,7 +29,7 @@
       value: {
         text: 'Yes' if user['order-devices'] else 'No'
       }
-    } if isSchoolUser,
+    } if isSchoolUser and not data.features['order-in-service'],
     {
       key: {
         text: "Last sign-in"

--- a/app/views/_shared/chromebooks/_fields.html
+++ b/app/views/_shared/chromebooks/_fields.html
@@ -1,30 +1,5 @@
-{% if data.features['further-education'] %}
-  {% set listOfOrgModifier = ', college or ' %}
-{% else %}
-  {% set listOfOrgModifier = ' or ' %}
-{% endif %}
-
 {% set chromebookFields %}
-  {{ govukInput({
-    label: {
-      text: 'School' + listOfOrgModifier + 'local authority domain registered for G Suite for Education',
-      classes: 'govuk-label--s'
-    },
-    hint: {
-      text: 'For example, ‘school.co.uk’'
-    }
-  } | decorateFormAttributes(["domain"] if isSchool else ["responsible-body", school.URN, "domain"]) ) }}
-
-  {{ govukInput({
-    label: {
-      text: 'Recovery email address',
-      classes: 'govuk-label--s'
-    },
-    hint: {
-      text: 'This email address must be on a different domain to the school' + listOfOrgModifier + 'local authority domain. For example, if the domain is ‘school.com’, then the email must not be ‘recovery@school.com’.'
-    }
-  } | decorateFormAttributes(["recovery"] if isSchool else ["responsible-body", school.URN, "recovery"]) ) }}
-
+  {% include '_shared/chromebooks/_yes-fields.html' %}
 
   <p class="govuk-!-margin-top-4">
     If you need help finding these details, email <a href="#">COVID.TECHNOLOGY@education.gov.uk</a>

--- a/app/views/_shared/chromebooks/_yes-fields.html
+++ b/app/views/_shared/chromebooks/_yes-fields.html
@@ -1,0 +1,25 @@
+{% if data.features['further-education'] %}
+  {% set listOfOrgModifier = ', college or ' %}
+{% else %}
+  {% set listOfOrgModifier = ' or ' %}
+{% endif %}
+
+{{ govukInput({
+  label: {
+    text: 'School' + listOfOrgModifier + 'local authority domain registered for G Suite for Education',
+    classes: 'govuk-label--s'
+  },
+  hint: {
+    text: 'For example, ‘school.co.uk’'
+  }
+} | decorateFormAttributes(["domain"] if isSchool else ["responsible-body", school.URN, "domain"]) ) }}
+
+{{ govukInput({
+  label: {
+    text: 'Recovery email address',
+    classes: 'govuk-label--s'
+  },
+  hint: {
+    text: 'This email address must be on a different domain to the school' + listOfOrgModifier + 'local authority domain. For example, if the domain is ‘school.com’, then the email must not be ‘recovery@school.com’.'
+  }
+} | decorateFormAttributes(["recovery"] if isSchool else ["responsible-body", school.URN, "recovery"]) ) }}

--- a/app/views/_shared/invite/_school-fields.html
+++ b/app/views/_shared/invite/_school-fields.html
@@ -20,26 +20,27 @@
   }
 } | decorateFormAttributes(["school", "new-invite-number"]) )}}
 
-
-{{ govukRadios({
-  fieldset: {
-    legend: {
-      text: "Will they place orders for devices?",
-      classes: "govuk-fieldset__legend--s" if isNested else "govuk-fieldset__legend--m"
-    }
-  },
-  hint: {
-    text: "No more than " + data['max-school-order-users'] + " users will be allowed to place orders."
-  },
-  items: [
-    {
-      text: "Yes, give them access to order on the TechSource website",
-      hint: {
-        html: 'This is where they’ll place orders.<br />They’ll also get access to a Support Portal.'
+{% if not data.features['order-in-service'] %}
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "Will they place orders for devices?",
+        classes: "govuk-fieldset__legend--s" if isNested else "govuk-fieldset__legend--m"
       }
     },
-    {
-      text: "No"
-    }
-  ]
-} | decorateFormAttributes(["responsible-body", "can-order-devices"]) ) }}
+    hint: {
+      text: "No more than " + data['max-school-order-users'] + " users will be allowed to place orders."
+    },
+    items: [
+      {
+        text: "Yes, give them access to order on the TechSource website",
+        hint: {
+          html: 'This is where they’ll place orders.<br />They’ll also get access to a Support Portal.'
+        }
+      },
+      {
+        text: "No"
+      }
+    ]
+  } | decorateFormAttributes(["responsible-body", "can-order-devices"]) ) }}
+{% endif %}

--- a/app/views/_shared/school/_allocation-description.html
+++ b/app/views/_shared/school/_allocation-description.html
@@ -2,5 +2,4 @@
   <li>{% if data.features['further-education'] %}students in year 3 and above{% else %}the number of children in years 3 to 11{% endif %}</li>
   <li>free school meals data</li>
   <li>an estimate of the number of devices your school{% if data.features['further-education'] %}, or college,{% endif %} already has</li>
-  <li>the number of devices we think you may need if you have a bubble <span class='app-no-wrap'>self-isolating</span></li>
 </ul>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -32,6 +32,7 @@
 {% from "_components/task-list/macro.njk"      import appTaskList %}
 {% from "_components/banner/macro.njk"         import appBanner %}
 {% from "_components/related/macro.njk"        import appRelated %}
+{% from "_components/summary-card/macro.njk"   import appSummaryCard %}
 {% from "_components/_sectionNav.njk" import sectionNav %}
 
 {% block head %}

--- a/app/views/school/devices-you-can-order.html
+++ b/app/views/school/devices-you-can-order.html
@@ -1,10 +1,9 @@
 {% extends "_wizard-form.html" %}
-{% set isOrderUser = data['school-details'].order_user %}
-{% if data.features.iss %}
-  {% set title = "Laptops you can order" %}
-{% else %}
-  {% set title = "You can order a range of laptops and tablets" if isOrderUser else "Your school can order a range of laptops and tablets" %}
+{% if  data.features['order-in-service'] %}
+  {% set buttonText = 'Finish and go to homepage' %}
 {% endif %}
+
+{% set title = "You can order a range of devices" %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">
@@ -14,15 +13,16 @@
 {% if data.features.iss %}
   {% include '_shared/responsible-body/la-funded-places/_laptops-you-can-order.html' %}
 {% else %}
-  <p>Your school{% if data.features['further-education'] %}, or college,{% endif %} will own the devices. It’s up to you to decide who will benefit most from them.</p>
+  <p>Your school or college will own the devices. It’s up to you to decide who will benefit most from them.</p>
 
   <p>You can choose from:</p>
-
   <ul class="govuk-list govuk-list--bullet">
-    <li>Microsoft Windows laptop</li>
-    <li>Google Chromebook</li>
+    <li>Microsoft Windows laptops</li>
+    <li>Microsoft Windows laptops with DfE settings installed</li>
+    <li>Google Chromebooks</li>
   </ul>
-  <p class="govuk-!-margin-bottom-6"><a href="#">Read more about the device specifications</a></p>
+
+  <p>You can also request 4G wireless routers.</p>
 {% endif %}
 
 {% endblock %}

--- a/app/views/school/devices/check.html
+++ b/app/views/school/devices/check.html
@@ -61,7 +61,7 @@
         },
         {
           key: {
-            text: "Setting:"
+            text: "Setting"
           },
           value: {
               text: data['school-details'].type

--- a/app/views/school/devices/order-history.html
+++ b/app/views/school/devices/order-history.html
@@ -1,0 +1,56 @@
+{% extends "layout.html" %}
+{% set title = "Order history" %}
+{% set lockdown = false %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/school"
+      },
+      {
+        text: "Order history"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+
+    <p>Orders placed on TechSource are not shown. Sign in to <a href="#">TechSource</a> to see details of orders placed before 1 May 2021.</p>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">Date</th>
+          <th class="govuk-table__header">Order</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">10 May 2021</td>
+          <td class="govuk-table__cell">
+            <span class="app-!-font-family-tabular govuk-!-margin-right-1">5</span> 4G wireless routers<br />
+            <span class="govuk-hint">Order reference: HDJ2123F</span> <a href="#">View order</a>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">2 May 2021</td>
+          <td class="govuk-table__cell">
+            <span class="app-!-font-family-tabular govuk-!-margin-right-1">20</span> Microsoft Windows laptops<br />
+            <span class="govuk-hint">Order reference: ABC2123E</span> <a href="#">View order</a></td>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/school/devices/order-history.html
+++ b/app/views/school/devices/order-history.html
@@ -49,7 +49,7 @@
             <span class="app-!-font-family-tabular govuk-!-margin-right-1">20</span> Microsoft Windows laptops<br />
             <span class="govuk-hint">Order reference: ABC2123E</span> <a href="/school/devices/previous-order">View order</a>
           </td>
-          <td class="govuk-table__cell">Despatched</td>
+          <td class="govuk-table__cell">Dispatched</td>
         </tr>
       </tbody>
     </table>

--- a/app/views/school/devices/order-history.html
+++ b/app/views/school/devices/order-history.html
@@ -31,6 +31,7 @@
         <tr class="govuk-table__row">
           <th class="govuk-table__header">Date</th>
           <th class="govuk-table__header">Order</th>
+          <th class="govuk-table__header">Status</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -38,19 +39,20 @@
           <td class="govuk-table__cell">10 May 2021</td>
           <td class="govuk-table__cell">
             <span class="app-!-font-family-tabular govuk-!-margin-right-1">5</span> 4G wireless routers<br />
-            <span class="govuk-hint">Order reference: HDJ2123F</span> <a href="#">View order</a>
+            <span class="govuk-hint">Order reference: HDJ2123F</span> <a href="/school/devices/previous-order">View order</a>
           </td>
+          <td class="govuk-table__cell">Processing</td>
         </tr>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">2 May 2021</td>
           <td class="govuk-table__cell">
             <span class="app-!-font-family-tabular govuk-!-margin-right-1">20</span> Microsoft Windows laptops<br />
-            <span class="govuk-hint">Order reference: ABC2123E</span> <a href="#">View order</a></td>
+            <span class="govuk-hint">Order reference: ABC2123E</span> <a href="/school/devices/previous-order">View order</a>
           </td>
+          <td class="govuk-table__cell">Despatched</td>
         </tr>
       </tbody>
     </table>
-
   </div>
 </div>
 {% endblock %}

--- a/app/views/school/devices/order-in-service.html
+++ b/app/views/school/devices/order-in-service.html
@@ -1,0 +1,51 @@
+{% extends "layout.html" %}
+{% set title = "Order devices" %}
+{% set lockdown = false %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/school"
+      },
+      {
+        text: "Order devices"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+
+    <div class="app-order-card">
+      <h1 class="govuk-panel__title govuk-!-font-size-36 govuk-!-margin-bottom-2">
+        82 devices available
+      </h1>
+      <div class="govuk-panel__body govuk-!-font-size-24">
+        You’ve ordered 0 of 82 devices
+      </div>
+    </div>
+
+    <h2 class="govuk-heading-m">
+      How you order devices has changed
+    </h2>
+
+    <p>You can now place orders directly on this service. You no longer need to sign in to TechSource.</p>
+
+    <p>Most devices will be delivered within 5 working days.</p>
+
+    {{ govukButton({
+      text: 'Order devices',
+      href: '/school/shop',
+      classes: 'govuk-!-margin-top-4'
+    }) }}
+  </div>
+</div>
+{% endblock %}

--- a/app/views/school/devices/previous-order.html
+++ b/app/views/school/devices/previous-order.html
@@ -79,7 +79,7 @@
             text: "Status"
           },
           value: {
-            html: "Despatched"
+            html: "Dispatched"
           }
         },
         {

--- a/app/views/school/devices/previous-order.html
+++ b/app/views/school/devices/previous-order.html
@@ -1,0 +1,146 @@
+{% extends "layout.html" %}
+{% set title = "Your order (HDJ2123F)" %}
+{% set lockdown = false %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/school"
+      },
+      {
+        text: "Order history",
+        href: "/school/devices/order-history"
+      },
+      {
+        text: title
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ title }}
+    </h1>
+
+    {% set devicesHtml %}
+      <span class="app-!-font-family-tabular govuk-!-margin-right-1">10</span> Microsoft Windows laptops
+    {% endset %}
+
+    {% set routersHtml %}
+      <span class="app-!-font-family-tabular govuk-!-margin-right-1">10</span> 4G wireless routers
+    {% endset %}
+
+    {% set deliveryContactHtml %}
+      {% if data['shop-delivery-who'] == 'someone-else' %}
+        Jane Doe<br />
+        jane.doe@school.gov.uk<br />
+        01234 321456
+      {% else %}
+        My Name<br />
+        my-email@my-email.com<br />
+        01234 123456
+      {% endif %}
+    {% endset %}
+
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: {
+            text: "Date"
+          },
+          value: {
+            html: "2 May 2021"
+          }
+        },
+        {
+          key: {
+            text: "Reference"
+          },
+          value: {
+            html: "HDJ2123F"
+          }
+        },
+        {
+          key: {
+            text: "Placed by"
+          },
+          value: {
+            html: "John Hancock"
+          }
+        },
+        {
+          key: {
+            text: "Status"
+          },
+          value: {
+            html: "Despatched"
+          }
+        },
+        {
+          key: {
+            text: "Devices"
+          },
+          value: {
+            html: devicesHtml
+          }
+        },
+        {
+          key: {
+            text: "Routers"
+          },
+          value: {
+            html: routersHtml
+          }
+        },
+        {
+          key: {
+            text: "Type of Windows devices"
+          },
+          value: {
+            text: "Standard"
+          }
+        },
+        {
+          key: {
+            text: "Google Chromebook: Domain"
+          },
+          value: {
+            text: "schooldomain.com"
+          }
+        },
+        {
+          key: {
+            text: "Google Chromebook: Recovery email address"
+          },
+          value: {
+            text: "email@email.com"
+          }
+        },
+        {
+          key: {
+            text: "Delivery contact"
+          },
+          value: {
+            html: deliveryContactHtml
+          }
+        },
+        {
+          key: {
+            text: "Delivery address"
+          },
+          value: {
+            html: "Pool Hayes Primary<br>72 Guild Street<br>London<br>SE23 6FH"
+          }
+        }
+      ]
+    }) }}
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/school/index.html
+++ b/app/views/school/index.html
@@ -10,11 +10,7 @@
   {{ govukBreadcrumbs({
     items: [
       {
-        text: "Home",
-        href: "#"
-      },
-      {
-        text: title
+        text: "Home"
       }
     ]
   }) }}

--- a/app/views/school/index.html
+++ b/app/views/school/index.html
@@ -44,12 +44,10 @@
     </h2>
     <p>Use this section to:</p>
     <ul class="govuk-list govuk-list--bullet">
-    {% if data.features.iss %}
-{#       <li>tell us if you want to order Chromebooks</li> #}
-      <li>find out how to place orders on the TechSource website</li>
-      <li>find out about who owns the laptops</li>
-    {% else %}
       <li>place orders</li>
+    {% if data.features['order-in-service'] %}
+      <li>tell us which devices you want to order</li>
+    {% else %}
       <li>access the Computacenter TechSource website</li>
     {% endif %}
     </ul>
@@ -121,11 +119,15 @@
     <h2 class="govuk-heading-l govuk-!-font-size-27">
       <a href="/school/users">Manage users</a>
     </h2>
-    <p>Use this section to give others{% if data.features['further-education'] == false %} in your school{% endif %}:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>access to this service</li>
-      <li>access to the TechSource website (where they’ll place orders)</li>
-    </ul>
+    {% if data.features['order-in-service'] %}
+      <p>Use this section to give others access to this service.</p>
+    {% else %}
+      <p>Use this section to give others:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>access to this service</li>
+        <li>access to the TechSource website (where they’ll place orders)</li>
+      </ul>
+    {% endif %}
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/school/index.html
+++ b/app/views/school/index.html
@@ -34,7 +34,9 @@
   <div class="govuk-grid-column-two-thirds">
 
     <h2 class="govuk-heading-l govuk-!-font-size-27">
-    {% if data.features.iss %}
+    {% if data.features['order-in-service'] %}
+      <a href="/school/devices/order-in-service">Order devices</a>
+    {% elseif data.features.iss %}
       <a href="/responsible-body/devices/la-funded-pupils">Get laptops</a>
     {% else %}
       <a href="/school/devices/order-lockdown">Order devices</a>

--- a/app/views/school/users/index.html
+++ b/app/views/school/users/index.html
@@ -23,12 +23,19 @@
       {{ title }}
     </h1>
 
-    <p>No more than {{ data['max-school-order-users'] }} users will be allowed to place orders.</p>
+    {% if not data.features['order-in-service'] %}
+      <p>No more than {{ data['max-school-order-users'] }} users will be allowed to place orders.</p>
+    {% endif %}
 
     <p>Everyone with access can:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+      {% if data.features['order-in-service'] %}
+        <li>place orders</li>
+      {% endif %}
       <li>add or edit existing users</li>
-      <li>change who places orders for devices</li>
+      {% if not data.features['order-in-service'] %}
+        <li>change who places orders for devices</li>
+      {% endif %}
     </ul>
 
     {{ govukButton({

--- a/app/views/school/welcome.html
+++ b/app/views/school/welcome.html
@@ -1,15 +1,15 @@
 {% extends "_wizard-form.html" %}
-{% set isOrderUser = data['school-details'].order_user %}
+
 {% if data.features.iss %}
   {% set title = "Get laptops for state-funded pupils at independent settings" %}
-  {% else %}
+{% else %}
   {% set title = "You’re signed in as " + data['school-details'].name %}
 {% endif %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">
     {% if data.features.iss %}
-      Get laptops for and internet access <span class="app-no-wrap">state-funded</span> pupils at independent settings
+      Get laptops and internet access for <span class="app-no-wrap">state-funded</span> pupils at independent settings
     {% else %}
       {{ title }}
     {% endif %}
@@ -34,14 +34,16 @@
     </li>
   </ul>
 {% else %}
-  <p>You can use the ‘Get help with technology’ service to:</p>
+  <p>You can use this service to:</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-    <li>check how many devices you can order</li>
-    {% if isOrderUser %}
-      <li>access the Computacenter TechSource website to place orders{% if not data.features.push %} when devices are made available{% endif %}</li>
+    {% if data.features['order-in-service'] %}
+      <li>place orders</li>
+    {% else %}
+      <li>access the Computacenter TechSource website to place orders</li>
+      <li>give us technical details for Chromebooks if you’ll be ordering them</li>
     {% endif %}
-    <li>give us technical details for Chromebooks if you’ll be ordering them</li>
-    <li>manage who can order devices</li>
+    <li>check how many devices you can order</li>
+    <li>manage who can use this service</li>
   </ul>
 {% endif %}
 {% endblock %}

--- a/app/views/school/what-next.html
+++ b/app/views/school/what-next.html
@@ -11,7 +11,9 @@
     <li>add more users</li>
     <li>change your Chromebook settings</li>
     <li>review your allocation</li>
-    <li>request devices for clinically vulnerable students who are shielding</li>
   </ul>
-  <p class="govuk-!-margin-bottom-6">When your TechSource account is ready you can order your devices.</p>
+
+  {% if not data.features['order-in-service'] %}
+    <p class="govuk-!-margin-bottom-6">When your TechSource account is ready you can order your devices.</p>
+  {% endif %}
 {% endblock %}

--- a/app/views/shop/address.html
+++ b/app/views/shop/address.html
@@ -5,7 +5,7 @@
   <h1 class="govuk-heading-xl">
     {{ title }}
   </h1>
-  
+
   <div class="app-order-card">
     <p class="govuk-!-margin-bottom-0">
       <strong>Pool Hayes Primary</strong><br>
@@ -14,4 +14,14 @@
       SE23 6FH
     </p>
   </div>
+
+  {% set detailsHtml %}
+    <p>This is the school address we have on record.</p>
+    <p>If it’s not right, email <a href="#">COVID.TECHNOLOGY@education.gov.uk</a> and tell us what to change.</p>
+  {% endset %}
+
+  {{ govukDetails({
+    summaryText: "Is there a problem with this address?",
+    html: detailsHtml
+  }) }}
 {% endblock %}

--- a/app/views/shop/chromebooks.html
+++ b/app/views/shop/chromebooks.html
@@ -1,0 +1,11 @@
+{% extends "_wizard-form.html" %}
+{% set title = "We need some details to configure your Chromebooks" %}
+
+{% block form %}
+  <h1 class="govuk-heading-xl">
+    {{ title }}
+  </h1>
+
+  {% set isSchool = true %}
+  {% include '_shared/chromebooks/_yes-fields.html' %}
+{% endblock %}

--- a/app/views/shop/confirm.html
+++ b/app/views/shop/confirm.html
@@ -13,7 +13,7 @@
   {% endset %}
 
   {% set routersHtml %}
-    <span class="app-!-font-family-tabular govuk-!-margin-right-1">10</span> 4G Wireless routers
+    <span class="app-!-font-family-tabular govuk-!-margin-right-1">10</span> 4G wireless routers
   {% endset %}
 
   {% set deliveryContactHtml %}

--- a/app/views/shop/confirm.html
+++ b/app/views/shop/confirm.html
@@ -22,9 +22,9 @@
       {{ data['shop-delivery-contact-email'] }}<br />
       {{ data['shop-delivery-contact-number'] }}
     {% else %}
-      My Name<br />
-      my-email@my-email.com<br />
-      01234 123456
+      Jane Doe<br />
+      email@email.com<br />
+      01234 345678
     {% endif %}
   {% endset %}
 

--- a/app/views/shop/confirm.html
+++ b/app/views/shop/confirm.html
@@ -1,11 +1,20 @@
 {% extends "_wizard-form.html" %}
-{% set buttonText = "Confirm order" %}
-{% set title = "Confirm your order details" %}
+{% set buttonText = "Place order" %}
+{% set title = "Confirm your details before placing your order" %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">
     {{ title }}
   </h1>
+
+  {% set devicesHtml %}
+    <span class="app-!-font-family-tabular govuk-!-margin-right-1">20</span> Microsoft Windows laptops<br />
+    <span class="app-!-font-family-tabular govuk-!-margin-right-1">10</span> Google Chromebooks
+  {% endset %}
+
+  {% set routersHtml %}
+    <span class="app-!-font-family-tabular govuk-!-margin-right-1">10</span> 4G Wireless routers
+  {% endset %}
 
   {{ govukSummaryList({
     rows: [
@@ -14,7 +23,7 @@
           text: "Devices"
         },
         value: {
-          html: "20 Microsoft Windows laptops<br />10 Google Chromebooks"
+          html: devicesHtml
         },
         actions: {
           items: [
@@ -26,6 +35,23 @@
           ]
         }
       },
+      {
+        key: {
+          text: "Routers"
+        },
+        value: {
+          html: routersHtml
+        },
+        actions: {
+          items: [
+            {
+              href: "#",
+              text: "Change",
+              visuallyHiddenText: "name"
+            }
+          ]
+        }
+      } if data.routersAllocated > 0,
       {
         key: {
           text: "Type of Windows devices"

--- a/app/views/shop/confirm.html
+++ b/app/views/shop/confirm.html
@@ -16,6 +16,18 @@
     <span class="app-!-font-family-tabular govuk-!-margin-right-1">10</span> 4G Wireless routers
   {% endset %}
 
+  {% set deliveryContactHtml %}
+    {% if data['shop-delivery-who'] == 'someone-else' %}
+      {{ data['shop-delivery-contact-name'] }}<br />
+      {{ data['shop-delivery-contact-email'] }}<br />
+      {{ data['shop-delivery-contact-number'] }}
+    {% else %}
+      My Name<br />
+      my-email@my-email.com<br />
+      01234 123456
+    {% endif %}
+  {% endset %}
+
   {{ govukSummaryList({
     rows: [
       {
@@ -105,6 +117,23 @@
       } if data['recovery'],
       {
         key: {
+          text: "Delivery contact"
+        },
+        value: {
+          html: deliveryContactHtml
+        },
+        actions: {
+          items: [
+            {
+              href: "#",
+              text: "Change",
+              visuallyHiddenText: "contact information"
+            }
+          ]
+        }
+      },
+      {
+        key: {
           text: "Delivery address"
         },
         value: {
@@ -115,7 +144,7 @@
             {
               href: "#",
               text: "Change",
-              visuallyHiddenText: "contact information"
+              visuallyHiddenText: "delivery address"
             }
           ]
         }

--- a/app/views/shop/confirm.html
+++ b/app/views/shop/confirm.html
@@ -1,6 +1,6 @@
 {% extends "_wizard-form.html" %}
 {% set buttonText = "Place order" %}
-{% set title = "Confirm your details before placing your order" %}
+{% set title = "Check your order before confirming" %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">
@@ -28,127 +28,165 @@
     {% endif %}
   {% endset %}
 
-  {{ govukSummaryList({
-    rows: [
-      {
-        key: {
-          text: "Devices"
+  {% set orderingList %}
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: {
+            text: "Devices"
+          },
+          value: {
+            html: devicesHtml
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: "Change",
+                visuallyHiddenText: "which devices"
+              }
+            ]
+          }
         },
-        value: {
-          html: devicesHtml
-        },
-        actions: {
-          items: [
-            {
-              href: "#",
-              text: "Change",
-              visuallyHiddenText: "name"
-            }
-          ]
+        {
+          key: {
+            text: "Routers"
+          },
+          value: {
+            html: routersHtml
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: "Change",
+                visuallyHiddenText: "how many routers"
+              }
+            ]
+          }
+        } if data.routersAllocated > 0
+      ]
+    }) }}
+  {% endset %}
+
+  {% set windowsList %}
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: {
+            text: "Type of Windows devices"
+          },
+          value: {
+            text: "Standard"
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: "Change",
+                visuallyHiddenText: "type of windows device"
+              }
+            ]
+          }
         }
-      },
-      {
-        key: {
-          text: "Routers"
+      ]
+    }) }}
+  {% endset %}
+
+  {% set deliveryList %}
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: {
+            text: "Delivery contact"
+          },
+          value: {
+            html: deliveryContactHtml
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: "Change",
+                visuallyHiddenText: "contact information"
+              }
+            ]
+          }
         },
-        value: {
-          html: routersHtml
-        },
-        actions: {
-          items: [
-            {
-              href: "#",
-              text: "Change",
-              visuallyHiddenText: "name"
-            }
-          ]
+        {
+          key: {
+            text: "Delivery address"
+          },
+          value: {
+            html: "Pool Hayes Primary<br>72 Guild Street<br>London<br>SE23 6FH"
+          }
         }
-      } if data.routersAllocated > 0,
-      {
-        key: {
-          text: "Type of Windows devices"
-        },
-        value: {
-          text: "Standard"
-        },
-        actions: {
-          items: [
-            {
-              href: "#",
-              text: "Change",
-              visuallyHiddenText: "date of birth"
-            }
-          ]
-        }
-      },
-      {
-        key: {
-          text: "Google Chromebook: Domain"
-        },
-        value: {
-          text: data['domain']
-        },
-        actions: {
-          items: [
-            {
-              href: "/responsible-body/devices/schools/" + school.URN + "/chromebooks",
-              text: "Change",
-              visuallyHiddenText: "name"
-            }
-          ]
-        }
-      } if data['domain'],
-      {
-        key: {
-          text: "Google Chromebook: Recovery email address"
-        },
-        value: {
-          text: data['recovery']
-        },
-        actions: {
-          items: [
-            {
-              href: "/responsible-body/devices/schools/" + school.URN + "/chromebooks",
-              text: "Change",
-              visuallyHiddenText: "name"
-            }
-          ]
-        }
-      } if data['recovery'],
-      {
-        key: {
-          text: "Delivery contact"
-        },
-        value: {
-          html: deliveryContactHtml
-        },
-        actions: {
-          items: [
-            {
-              href: "#",
-              text: "Change",
-              visuallyHiddenText: "contact information"
-            }
-          ]
-        }
-      },
-      {
-        key: {
-          text: "Delivery address"
-        },
-        value: {
-          html: "Pool Hayes Primary<br>72 Guild Street<br>London<br>SE23 6FH"
-        },
-        actions: {
-          items: [
-            {
-              href: "#",
-              text: "Change",
-              visuallyHiddenText: "delivery address"
-            }
-          ]
-        }
-      }
-    ]
+      ]
+    }) }}
+  {% endset %}
+
+  {% set chromebookList %}
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: {
+            text: "Domain registered for G Suite for Education"
+          },
+          value: {
+            text: data['domain']
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: "Change",
+                visuallyHiddenText: "domain"
+              }
+            ]
+          }
+        } if data['domain'],
+        {
+          key: {
+            text: "Recovery email address"
+          },
+          value: {
+            text: data['recovery']
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: "Change",
+                visuallyHiddenText: "recovery email address"
+              }
+            ]
+          }
+        } if data['recovery']
+      ]
+    }) }}
+  {% endset %}
+
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    titleText: "Your order",
+    html: orderingList
+  }) }}
+
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    titleText: "Microsoft Windows",
+    html: windowsList
+  }) }}
+
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    titleText: "Google Chromebooks",
+    html: chromebookList
+  }) }}
+
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    titleText: "Delivery",
+    html: deliveryList
   }) }}
 {% endblock %}

--- a/app/views/shop/confirm.html
+++ b/app/views/shop/confirm.html
@@ -14,7 +14,7 @@
           text: "Devices"
         },
         value: {
-          html: "30 Microsoft Windows laptops<br />10 Google Chromebooks"
+          html: "20 Microsoft Windows laptops<br />10 Google Chromebooks"
         },
         actions: {
           items: [
@@ -43,6 +43,40 @@
           ]
         }
       },
+      {
+        key: {
+          text: "Google Chromebook: Domain"
+        },
+        value: {
+          text: data['domain']
+        },
+        actions: {
+          items: [
+            {
+              href: "/responsible-body/devices/schools/" + school.URN + "/chromebooks",
+              text: "Change",
+              visuallyHiddenText: "name"
+            }
+          ]
+        }
+      } if data['domain'],
+      {
+        key: {
+          text: "Google Chromebook: Recovery email address"
+        },
+        value: {
+          text: data['recovery']
+        },
+        actions: {
+          items: [
+            {
+              href: "/responsible-body/devices/schools/" + school.URN + "/chromebooks",
+              text: "Change",
+              visuallyHiddenText: "name"
+            }
+          ]
+        }
+      } if data['recovery'],
       {
         key: {
           text: "Delivery address"

--- a/app/views/shop/confirmation.html
+++ b/app/views/shop/confirmation.html
@@ -14,7 +14,9 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">What happens next</h2>
 
-      <p>Devices will normally arrive within 2 working days.</p>
+      <p>Your delivery contact will receive a dispatch email from Computacenter giving details about your delivery.</p>
+
+      <p>Most devices will be delivered within 5 working days.</p>
 
       <hr class="govuk-section-break govuk-section-break--m">
 

--- a/app/views/shop/delivery-contact.html
+++ b/app/views/shop/delivery-contact.html
@@ -12,30 +12,89 @@
     <li>be contacted about any issues relating to the delivery</li>
   </ul>
 
+  {% set meHtml %}
+    {% set userHasTelephone = false %}
+
+    {{ govukSummaryList({
+    rows: [
+      {
+        key: {
+          text: "Name"
+        },
+        value: {
+          text: "Jane Doe"
+        }
+      },
+      {
+        key: {
+          text: "Email address"
+        },
+        value: {
+          text: "email@email.com"
+        }
+      },
+      {
+        key: {
+          text: "Telephone number"
+        },
+        value: {
+          text: "01234 345678"
+        }
+      } if userHasTelephone
+    ]
+    }) }}
+
+    {% if not userHasTelephone %}
+      {{ govukInput({
+        label: {
+          text: 'Your telephone number',
+          classes: 'govuk-label--s'
+        },
+        hint: {
+          text: 'A courier may need to call if there’s a problem with delivery'
+        }
+      } | decorateFormAttributes('shop-my-contact-number') ) }}
+    {% endif %}
+  {% endset %}
+
   {% set someoneElseHtml %}
+    <h3 class="govuk-heading-m">Delivery contact details</h3>
+
     {{ govukInput({
       label: {
-        text: 'Their name'
+        text: 'Their name',
+        classes: 'govuk-label--s'
       }
     } | decorateFormAttributes('shop-delivery-contact-name') ) }}
 
     {{ govukInput({
       label: {
-        text: 'Their email address'
+        text: 'Their email address',
+        classes: 'govuk-label--s'
       }
     } | decorateFormAttributes('shop-delivery-contact-email') ) }}
 
     {{ govukInput({
       label: {
-        text: 'Their telephone number'
+        text: 'Their telephone number',
+        classes: 'govuk-label--s'
       }
     } | decorateFormAttributes('shop-delivery-contact-number') ) }}
+
+    <h3 class="govuk-heading-m govuk-!-margin-top-6">Your contact details</h3>
+
+    <p>Your contact details will also be shared with Computacenter.</p>
+
+    {{ meHtml | safe }}
   {% endset %}
 
   {{ govukRadios({
     items: [
       {
-        text: 'I am the delivery contact'
+        text: 'I am the delivery contact',
+        conditional: {
+          html: meHtml
+        }
       },
       {
         text: 'Someone else is the delivery contact',

--- a/app/views/shop/delivery-contact.html
+++ b/app/views/shop/delivery-contact.html
@@ -8,7 +8,7 @@
 
   <p>The delivery contact will:</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-    <li>receive the despatch email from Computacenter</li>
+    <li>receive the dispatch email from Computacenter</li>
     <li>be contacted about any issues relating to the delivery</li>
   </ul>
 

--- a/app/views/shop/delivery-contact.html
+++ b/app/views/shop/delivery-contact.html
@@ -1,0 +1,49 @@
+{% extends "_wizard-form.html" %}
+{% set title = "Tell us who the delivery contact is" %}
+
+{% block form %}
+  <h1 class="govuk-heading-xl">
+    {{ title }}
+  </h1>
+
+  <p>The delivery contact will:</p>
+  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+    <li>receive the despatch email from Computacenter</li>
+    <li>be contacted about any issues relating to the delivery</li>
+  </ul>
+
+  {% set someoneElseHtml %}
+    {{ govukInput({
+      label: {
+        text: 'Their name'
+      }
+    } | decorateFormAttributes('shop-delivery-contact-name') ) }}
+
+    {{ govukInput({
+      label: {
+        text: 'Their email address'
+      }
+    } | decorateFormAttributes('shop-delivery-contact-email') ) }}
+
+    {{ govukInput({
+      label: {
+        text: 'Their telephone number'
+      }
+    } | decorateFormAttributes('shop-delivery-contact-number') ) }}
+  {% endset %}
+
+  {{ govukRadios({
+    items: [
+      {
+        text: 'I am the delivery contact'
+      },
+      {
+        text: 'Someone else is the delivery contact',
+        value: 'someone-else',
+        conditional: {
+          html: someoneElseHtml
+        }
+      }
+    ]
+  }  | decorateFormAttributes('shop-delivery-who') ) }}
+{% endblock %}

--- a/app/views/shop/how-many-routers.html
+++ b/app/views/shop/how-many-routers.html
@@ -1,0 +1,36 @@
+{% extends "_wizard-form.html" %}
+{% set multipleDeviceTypes = data['shop-devices'].length > 1 %}
+{% set title = "How many routers do you need?" %}
+
+{% block form %}
+    {% set howManyHtml %}
+      {{ govukInput({
+        label: {
+          text: 'How many 4G wireless routers?'
+        },
+        classes: 'govuk-input--width-4'
+      } | decorateFormAttributes('shop-amount-' + type) ) }}
+    {% endset %}
+
+    {{ govukRadios({
+      fieldset: {
+        legend: {
+          text: "How many 4G Wireless routers do you need?",
+          classes: "govuk-fieldset__legend--xl govuk-!-margin-bottom-6",
+          isPageHeading: true
+        }
+      },
+      items: [
+        {
+          text: 'Our full allocation of 10 routers'
+        },
+        {
+          text: 'Less than our allocation',
+          conditional: {
+            html: howManyHtml
+          }
+        }
+      ]
+    }  | decorateFormAttributes('shop-amount-routers-choice') ) }}
+
+{% endblock %}

--- a/app/views/shop/how-many-routers.html
+++ b/app/views/shop/how-many-routers.html
@@ -1,6 +1,6 @@
 {% extends "_wizard-form.html" %}
 {% set multipleDeviceTypes = data['shop-devices'].length > 1 %}
-{% set title = "How many 4G Wireless routers are you ordering?" %}
+{% set title = "How many 4G wireless routers are you ordering?" %}
 
 {% block form %}
     {% set howManyHtml %}

--- a/app/views/shop/how-many-routers.html
+++ b/app/views/shop/how-many-routers.html
@@ -1,6 +1,6 @@
 {% extends "_wizard-form.html" %}
 {% set multipleDeviceTypes = data['shop-devices'].length > 1 %}
-{% set title = "How many routers do you need?" %}
+{% set title = "How many 4G Wireless routers are you ordering?" %}
 
 {% block form %}
     {% set howManyHtml %}
@@ -15,7 +15,7 @@
     {{ govukRadios({
       fieldset: {
         legend: {
-          text: "How many 4G Wireless routers do you need?",
+          text: title,
           classes: "govuk-fieldset__legend--xl govuk-!-margin-bottom-6",
           isPageHeading: true
         }

--- a/app/views/shop/how-many.html
+++ b/app/views/shop/how-many.html
@@ -1,5 +1,5 @@
 {% extends "_wizard-form.html" %}
-{% set selectedRouters = '4G Wireless router' in data['shop-devices'] %}
+{% set selectedRouters = '4G wireless router' in data['shop-devices'] %}
 {% set multipleDeviceTypes = data['shop-devices'].length > 2 if selectedRouters else data['shop-devices'].length > 1 %}
 {% set title = "How many devices are you ordering?" %}
 
@@ -19,7 +19,7 @@
     </div>
 
     {% for type in data['shop-devices'] %}
-      {% if type != '4G Wireless router' %}
+      {% if type != '4G wireless router' %}
         {{ govukInput({
           label: {
             text: type + 's',

--- a/app/views/shop/how-many.html
+++ b/app/views/shop/how-many.html
@@ -22,7 +22,7 @@
       {% if type != '4G wireless router' %}
         {{ govukInput({
           label: {
-            text: type + 's',
+            text: 'How many ' + type + 's?',
             classes: 'govuk-label--m'
           },
           classes: 'govuk-input--width-4'

--- a/app/views/shop/how-many.html
+++ b/app/views/shop/how-many.html
@@ -1,5 +1,6 @@
 {% extends "_wizard-form.html" %}
-{% set multipleDeviceTypes = data['shop-devices'].length > 1 %}
+{% set selectedRouters = '4G Wireless router' in data['shop-devices'] %}
+{% set multipleDeviceTypes = data['shop-devices'].length > 2 if selectedRouters else data['shop-devices'].length > 1 %}
 {% set title = "How many devices do you need?" %}
 
 {% block form %}
@@ -18,13 +19,15 @@
     </div>
 
     {% for type in data['shop-devices'] %}
-      {{ govukInput({
-        label: {
-          text: type + 's',
-          classes: 'govuk-label--m'
-        },
-        classes: 'govuk-input--width-4'
-      } | decorateFormAttributes('shop-amount-' + type) ) }}
+      {% if type != '4G Wireless router' %}
+        {{ govukInput({
+          label: {
+            text: type + 's',
+            classes: 'govuk-label--m'
+          },
+          classes: 'govuk-input--width-4'
+        } | decorateFormAttributes('shop-routers-amount-' + type) ) }}
+      {% endif %}
     {% endfor %}
   {% else %}
 

--- a/app/views/shop/how-many.html
+++ b/app/views/shop/how-many.html
@@ -1,7 +1,7 @@
 {% extends "_wizard-form.html" %}
 {% set selectedRouters = '4G Wireless router' in data['shop-devices'] %}
 {% set multipleDeviceTypes = data['shop-devices'].length > 2 if selectedRouters else data['shop-devices'].length > 1 %}
-{% set title = "How many devices do you need?" %}
+{% set title = "How many devices are you ordering?" %}
 
 {% block form %}
   {% if multipleDeviceTypes %}
@@ -43,7 +43,7 @@
     {{ govukRadios({
       fieldset: {
         legend: {
-          text: "How many " + data['shop-devices'][0] + "s do you need?",
+          text: "How many " + data['shop-devices'][0] + "s are you ordering?",
           classes: "govuk-fieldset__legend--xl govuk-!-margin-bottom-6",
           isPageHeading: true
         }

--- a/app/views/shop/index.html
+++ b/app/views/shop/index.html
@@ -13,7 +13,10 @@
       },
       {
         text: 'Google Chromebook'
-      }
+      },
+      {
+        text: '4G Wireless router'
+      } if data.routersAllocated > 0
     ]
   }  | decorateFormAttributes('shop-devices') ) }}
 

--- a/app/views/shop/index.html
+++ b/app/views/shop/index.html
@@ -15,7 +15,7 @@
         text: 'Google Chromebook'
       },
       {
-        text: '4G Wireless router'
+        text: '4G wireless router'
       } if data.routersAllocated > 0
     ]
   }  | decorateFormAttributes('shop-devices') ) }}

--- a/app/views/shop/index.html
+++ b/app/views/shop/index.html
@@ -1,5 +1,5 @@
 {% extends "_wizard-form.html" %}
-{% set title = "Which devices do you need?" %}
+{% set title = "Which devices are you ordering?" %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">

--- a/app/views/shop/index.html
+++ b/app/views/shop/index.html
@@ -21,4 +21,6 @@
   }  | decorateFormAttributes('shop-devices') ) }}
 
   <p>Read more about <a href="https://get-help-with-tech.education.gov.uk/devices/device-specification">device specifications</a>.</p>
+
+  <p class="govuk-!-margin-bottom-6">Your school or college will own the devices. It’s up to you to decide who will benefit most from them.</p>
 {% endblock %}

--- a/app/views/shop/index.html
+++ b/app/views/shop/index.html
@@ -12,13 +12,7 @@
         text: 'Microsoft Windows laptop'
       },
       {
-        text: 'Microsoft Windows tablet'
-      },
-      {
         text: 'Google Chromebook'
-      },
-      {
-        text: 'Apple iPad'
       }
     ]
   }  | decorateFormAttributes('shop-devices') ) }}

--- a/app/views/shop/windows.html
+++ b/app/views/shop/windows.html
@@ -19,9 +19,6 @@
         hint: {
           text: 'Not configurable, with limitations on downloading certain software and changing the strict content filters that may prevent some browsers and conferencing tools from functioning.'
         }
-      },
-      {
-        text: 'Some of both'
       }
     ]
   }  | decorateFormAttributes('shop-windows-type') ) }}


### PR DESCRIPTION
Add:
- ability to order routers
- delivery contact details
- order history
- previous order view
- chromebook details
- order in service feature flag

Updates for ordering in service
- school wizard flow
- order users
- inviting new users (all users can order)
- brings order journey into flow

Also includes:
- summary card component
- updates to wizard helpers to allow forking based on things in/not in an array
- sets up routes for RB shop journey